### PR TITLE
changed primary blue to orange

### DIFF
--- a/data/tokens.json
+++ b/data/tokens.json
@@ -924,7 +924,7 @@
           "description": "global/tertiary/900\n#080C11"
         },
         "primary": {
-          "value": "{color.global.secondary.500}",
+          "value": "orange",
           "type": "color",
           "description": "global/secondary/500\n#4DACFF"
         },


### PR DESCRIPTION
Changing the primary blue color in the dark theme to orange to test the Figma token plugin instructions. This color is used throughout the UI, so it is a good, visible example to test with.