### PR TITLE
added new container and card border color tokens

### DIFF
--- a/data/tokens.json
+++ b/data/tokens.json
@@ -773,6 +773,24 @@
             "description": "A muted version of the primary color used for interactive elements in the Global Status Bar."
           }
         }
+      },
+      "card": {
+        "border": {
+          "default": {
+            "value": "{color.palette.grey.700}",
+            "type": "color",
+            "description": "The border color used for the Card component."
+          }
+        }
+      },
+      "container": {
+        "border": {
+          "default": {
+            "value": "{color.palette.neutral.1000}",
+            "type": "color",
+            "description": "The border color used for the Container component."
+          }
+        }
       }
     },
     "radius": {


### PR DESCRIPTION
Adding dark theme tokens for card border color and container border color for our new components. Will add light theme tokens when we have the values for them. These border colors are currently only used in the card and container components respectively.