### PR TITLE
astro-3230 fixed a few color token descriptions

### DIFF
--- a/data/tokens.json
+++ b/data/tokens.json
@@ -458,7 +458,7 @@
           "header": {
             "value": "{color.palette.darkblue.900}",
             "type": "color",
-            "description": "\t The background color for the header of base elements."
+            "description": "The background color for the header of base elements."
           },
           "hover": {
             "value": "{color.palette.brightblue.850}",
@@ -610,7 +610,7 @@
         "topsecretsci": {
           "value": "{color.palette.yellow.500}",
           "type": "color",
-          "description": "The color used to indicate the Top Secret/SCI classification."
+          "description": "The color used to indicate the Top Secret//SCI classification."
         },
         "topsecret": {
           "value": "{color.palette.orange.700}",
@@ -645,7 +645,7 @@
           "fill": {
             "value": "{color.palette.brightblue.700}",
             "type": "color",
-            "description": "The fill color of the Pop Up Menu's caret"
+            "description": "The fill color of the Pop Up Menu's caret."
           }
         }
       }
@@ -1052,7 +1052,7 @@
           "topsecretsci": {
             "value": "{color.classification.topsecretsci}",
             "type": "color",
-            "description": "The background color of the Top Secret/SCI classification banner."
+            "description": "The background color of the Top Secret//SCI classification banner."
           },
           "topsecret": {
             "value": "{color.classification.topsecret}",


### PR DESCRIPTION
Removed incorrect preceding spacing, fixed a missing period, and added another slash for the proper description of the Top Secret//SCI classification.