### PR TITLE
Astro-3344 Simplify dialog shadow

### DIFF
--- a/data/tokens.json
+++ b/data/tokens.json
@@ -1015,28 +1015,18 @@
       }
     },
     "opacity": {
-      "12": {
-        "value": "12%",
-        "description": "dialog-shadow-2",
-        "type": "opacity"
-      },
-      "14": {
-        "value": "14%",
-        "description": "dialog shadow 1 light",
-        "type": "opacity"
-      },
-      "20": {
-        "value": "20%",
-        "description": "dialog-shadow-3",
-        "type": "opacity"
-      },
-      "25": {
-        "value": "25%",
-        "description": "dialog-shadow-1",
+      "35": {
+        "value": "35%",
+        "description": "Used in drop shadow for dialogs in light theme",
         "type": "opacity"
       },
       "40": {
         "value": "40%",
+        "type": "opacity"
+      },
+      "45": {
+        "value": "45%",
+        "description": "Used in drop shadow for dialogs",
         "type": "opacity"
       },
       "50": {
@@ -1104,26 +1094,10 @@
           "value": [
             {
               "x": "0",
-              "y": "0",
-              "blur": "4",
-              "spread": "0",
-              "color": "rgba({color.palette.neutral.1000}, {opacity.25})",
-              "type": "dropShadow"
-            },
-            {
-              "x": "0",
               "y": "4",
               "blur": "4",
-              "spread": "3",
-              "color": "rgba({color.palette.neutral.1000}, {opacity.12})",
-              "type": "dropShadow"
-            },
-            {
-              "x": "0",
-              "y": "4",
-              "blur": "4",
-              "spread": "0",
-              "color": "rgba({color.palette.neutral.1000}, {opacity.40})",
+              "spread": "1",
+              "color": "rgba({color.palette.neutral.1000}, {opacity.45})",
               "type": "dropShadow"
             }
           ],
@@ -1732,26 +1706,10 @@
           "value": [
             {
               "x": "0",
-              "y": "0",
+              "y": "4",
               "blur": "4",
               "spread": "1",
-              "color": "rgba({color.palette.neutral.1000}, {opacity.14})",
-              "type": "dropShadow"
-            },
-            {
-              "x": "0",
-              "y": "4",
-              "blur": "4",
-              "spread": "3",
-              "color": "rgba({color.palette.neutral.1000}, {opacity.12})",
-              "type": "dropShadow"
-            },
-            {
-              "x": "0",
-              "y": "4",
-              "blur": "4",
-              "spread": "0",
-              "color": "rgba({color.palette.neutral.1000}, {opacity.20})",
+              "color": "rgba({color.palette.neutral.1000}, {opacity.35})",
               "type": "dropShadow"
             }
           ],


### PR DESCRIPTION
Changed dialog to use a single drop shadow instead of three. There are changes in opacity usage for the dialog shadow as well.

Figma branch: https://www.figma.com/file/3tYLyBkvKYOdUysPk6Fu60/branch/VwSK1NtSwiPtUiuMqOt9Ja/Astro-UXDS-7.0-BETA---Dark-Theme?node-id=261%3A1831

Jira ticket: https://rocketcom.atlassian.net/browse/ASTRO-3344