### PR TITLE
astro-3488-create-menu-divider-color-token

### DIFF
--- a/data/tokens.json
+++ b/data/tokens.json
@@ -1485,6 +1485,17 @@
         "type": "borderWidth",
         "description": "Extra small border width"
       }
+    },
+    "menu": {
+      "divider": {
+        "color": {
+          "fill": {
+            "value": "{color.palette.grey.700}",
+            "type": "color",
+            "description": "The fill color for menu dividers"
+          }
+        }
+      }
     }
   },
   "light": {


### PR DESCRIPTION
Added component token for menu divider color.

https://rocketcom.atlassian.net/browse/ASTRO-3488

https://www.figma.com/file/3tYLyBkvKYOdUysPk6Fu60/branch/L6pxQp8CU356ZNV5gKSlF6/Astro-UXDS-7.0-BETA---Dark-Theme?node-id=15405%3A114134