### PR TITLE
deleted borderless button border color

### DIFF
--- a/.changeset/great-eyes-boil.md
+++ b/.changeset/great-eyes-boil.md
@@ -1,0 +1,5 @@
+---
+"@astrouxds/design-tokens": major
+---
+
+removes `button-color-border-borderless` token

--- a/data/tokens.json
+++ b/data/tokens.json
@@ -644,17 +644,6 @@
         }
       }
     },
-    "button": {
-      "color": {
-        "border": {
-          "borderless": {
-            "value": "rgba({color.palette.brightblue.500}, 0)",
-            "type": "color",
-            "description": "The color used for the border of borderless buttons, to ensure they are the same size as other buttons."
-          }
-        }
-      }
-    },
     "link": {
       "color": {
         "text": {


### PR DESCRIPTION
Since we changed our border plans, we no longer need a component token for a transparent color for borderless buttons, so I deleted the token and Color Style.

https://rocketcom.atlassian.net/browse/ASTRO-3339

https://www.figma.com/file/3tYLyBkvKYOdUysPk6Fu60/branch/ZpnkWAsfjasvh37EzwWa3v/Astro-UXDS-7.0-BETA---Dark-Theme?node-id=6249%3A138443