### PR TITLE
Use unitless number line-heights

### DIFF
--- a/build.js
+++ b/build.js
@@ -260,6 +260,7 @@ StyleDictionary.registerFormat({
 StyleDictionary.registerTransformGroup({
   name: "custom/css",
   transforms: StyleDictionary.transformGroup["css"].concat([
+    "size/pxToUnitless",
     "size/pxToRem",
     "letterSpacing/percentToEm",
     "fontFamily/fallback",
@@ -272,6 +273,7 @@ StyleDictionary.registerTransformGroup({
 StyleDictionary.registerTransformGroup({
   name: "custom/scss",
   transforms: StyleDictionary.transformGroup["less"].concat([
+    "size/pxToUnitless",
     "size/pxToRem",
     "letterSpacing/percentToEm",
     "fontFamily/fallback",
@@ -284,6 +286,7 @@ StyleDictionary.registerTransformGroup({
 StyleDictionary.registerTransformGroup({
   name: "custom/json",
   transforms: StyleDictionary.transformGroup["web"].concat([
+    "size/pxToUnitless",
     "size/pxToRem",
     "letterSpacing/percentToEm",
     "fontFamily/fallback",

--- a/transforms/index.js
+++ b/transforms/index.js
@@ -2,6 +2,7 @@ module.exports = {
 	attributeCTI: require('./attributeCTI'),
 	colorRGB: require('./colorRGB'),
 	percentToEm: require('./percentToEm'),
+	pxToUnitless: require('./pxToUnitless'),
 	pxToRem: require('./pxToRem'),
 	remToFloat: require('./remToFloat'),
 	shadowCSS: require('./shadowCSS'),

--- a/transforms/pxToUnitless.js
+++ b/transforms/pxToUnitless.js
@@ -1,0 +1,38 @@
+/** Returns tokens by file from a token. */
+let getTokens = (/** @type {{ filePath: string }} */ token) => {
+	/** Filepath to the current token. */
+	let pathToTokens = '../' + token.filePath
+
+	/** Whether tokens have already been made available. */
+	let areTokensAvailable = pathToTokens in getTokens
+
+	// if tokens are not available
+	if (!areTokensAvailable) {
+		// require the tokens
+		getTokens[pathToTokens] = require(pathToTokens)
+	}
+
+	return getTokens[filePath]
+}
+
+/** Returns the font size for a given token. */
+let getFontSize = (token) => {
+	let tokens = getTokens(token)
+	let fontSize = tokens?.[token.attributes.category]?.[token.attributes.type]?.fontSize?.value
+
+	return fontSize
+}
+
+module.exports = {
+	name: "size/pxToUnitless",
+	type: "value",
+	matcher: (token) => {
+		return token.type === 'lineHeight'
+	},
+	transformer: (token) => {
+		let fontSize = parseFloat(getFontSize(token))
+		let lineHeight = parseFloat(token.value)
+
+		return `calc(${lineHeight} / ${fontSize})`;
+	}
+}

--- a/transforms/pxToUnitless.js
+++ b/transforms/pxToUnitless.js
@@ -12,7 +12,7 @@ let getTokens = (/** @type {{ filePath: string }} */ token) => {
 		getTokens[pathToTokens] = require(pathToTokens)
 	}
 
-	return getTokens[filePath]
+	return getTokens[pathToTokens]
 }
 
 /** Returns the font size for a given token. */


### PR DESCRIPTION
This pull request changes line heights from pixel dimensions to `calc()` expressions which resolve to a number.

A unitless line height will be multiplied by the element's own font size. In most cases, this is the preferred way to set `line-height` and avoid unexpected results due to inheritance.