### PR TITLE
remove light link tokens

### DIFF
--- a/data/tokens.json
+++ b/data/tokens.json
@@ -1711,22 +1711,6 @@
         }
       }
     },
-    "link": {
-      "color": {
-        "text": {
-          "default": {
-            "value": "{color.text.interactive.default}",
-            "type": "color",
-            "description": "The color used for links in default state."
-          },
-          "hover": {
-            "value": "{link.color.text.default}",
-            "type": "color",
-            "description": "The color used for links in hover state. Links do not change color on hover."
-          }
-        }
-      }
-    },
     "popup-menu": {
       "caret": {
         "color": {


### PR DESCRIPTION
removes the light theme link tokens. they're referencing interactive and thats the thing that gets changed so having them defined in light theme is just redundant 