### PR TITLE
remove light theme tag shadows

### DIFF
--- a/.changeset/pink-ties-travel.md
+++ b/.changeset/pink-ties-travel.md
@@ -1,0 +1,5 @@
+---
+"@astrouxds/design-tokens": major
+---
+
+removes --tag-shadow-inner-off, --tag-shadow-inner-critical, --tag-shadow-inner-normal for light theme only. These token values do not change

--- a/data/tokens.json
+++ b/data/tokens.json
@@ -1730,48 +1730,6 @@
         }
       }
     },
-    "tag": {
-      "shadow": {
-        "inner": {
-          "normal": {
-            "value": {
-              "x": "0",
-              "y": "0",
-              "blur": "5",
-              "spread": "0",
-              "color": "{status-symbol.color.fill.normal.on-dark}",
-              "type": "innerShadow"
-            },
-            "type": "boxShadow",
-            "description": "Inner shadow for normal status Tags"
-          },
-          "critical": {
-            "value": {
-              "x": "0",
-              "y": "0",
-              "blur": "5",
-              "spread": "0",
-              "color": "{status-symbol.color.fill.critical.on-dark}",
-              "type": "innerShadow"
-            },
-            "type": "boxShadow",
-            "description": "Inner shadow for critical status Tags"
-          },
-          "off": {
-            "value": {
-              "x": "0",
-              "y": "0",
-              "blur": "5",
-              "spread": "0",
-              "color": "{status-symbol.color.fill.off.on-dark}",
-              "type": "innerShadow"
-            },
-            "type": "boxShadow",
-            "description": "Inner shadow for off status Tags"
-          }
-        }
-      }
-    },
     "dialog": {
       "shadow": {
         "outer": {


### PR DESCRIPTION
Removes `--tag-shadow-inner-off`, `--tag-shadow-inner-critical`, and `--tag-shadow-inner-normal` tokens for light mode only. These values no longer change since introducing the `--status-symbol-color-fill-XXX-on-{light|dark}` tokens. 

Note that these component tokens are referencing the status symbol's component tokens which will be addressed in a later PR 