### PR TITLE
Quick fix to DT descriptions for red and orange error synonyms

### DIFF
--- a/data/tokens.json
+++ b/data/tokens.json
@@ -552,7 +552,7 @@
         "error": {
           "value": "{color.palette.red.500}",
           "type": "color",
-          "description": "The text color used for error messages."
+          "description": "The text color used for form error messages."
         }
       },
       "border": {
@@ -576,19 +576,19 @@
         "error": {
           "value": "{color.palette.red.500}",
           "type": "color",
-          "description": "The border color used for error messages."
+          "description": "The border color used for form error borders."
         }
       },
       "status": {
         "critical": {
           "value": "{color.palette.red.500}",
           "type": "color",
-          "description": "The color used to indicate items with a Critical status. Critical, error, alert, emergency, urgent."
+          "description": "The color used to indicate items with a Critical status. Critical, form error, alert, emergency, urgent."
         },
         "serious": {
           "value": "{color.palette.orange.500}",
           "type": "color",
-          "description": "The color used to indicate items with a Serious status. Serious, warning, needs attention."
+          "description": "The color used to indicate items with a Serious status. Serious, warning, error, needs attention."
         },
         "caution": {
           "value": "{color.palette.yellow.500}",


### PR DESCRIPTION
Jira: https://rocketcom.atlassian.net/browse/ASTRO-3968

As per Duncan's request to defer further red vs. orange error definition discussions, we are splitting the difference. Red will have "form error" instead of "error" in its description. Orange will have just "error" in its description to go with the intended status symbol usage.