### PR TITLE
Use consistent voice in descriptions

### DIFF
--- a/.changeset/nice-otters-switch.md
+++ b/.changeset/nice-otters-switch.md
@@ -1,0 +1,5 @@
+---
+"@astrouxds/tokens": patch
+---
+
+format descriptions

--- a/data/tokens.json
+++ b/data/tokens.json
@@ -4,20 +4,21 @@
       "25": {
         "value": "25%",
         "type": "opacity",
-        "description": "used in drop shadow for scrollbars in light theme "
+        "description": "Opacity used in drop shadow for scrollbars in light theme"
       },
       "35": {
         "value": "35%",
-        "description": "Used in drop shadow for dialogs in light theme",
+        "description": "Opacity used in drop shadow for dialogs in light theme",
         "type": "opacity"
       },
       "40": {
         "value": "40%",
-        "type": "opacity"
+        "type": "opacity",
+        "description": "Opacity used in disabled states"
       },
       "45": {
         "value": "45%",
-        "description": "Used in drop shadow for dialogs",
+        "description": "Opacity used in drop shadow for dialogs",
         "type": "opacity"
       },
       "50": {
@@ -493,19 +494,19 @@
       "lg": {
         "value": "4px",
         "type": "borderWidth",
-        "description": "large border width"
+        "description": "Large border width"
       }
     },
     "radius": {
       "base": {
         "value": "3px",
         "type": "borderRadius",
-        "description": "The default base border radius"
+        "description": "Default base border radius"
       },
       "circle": {
         "value": "50%",
         "type": "borderRadius",
-        "description": "A completely rounded border radius, used to create circles."
+        "description": "Completely rounded border radius, used to create circles"
       }
     },
     "fontFamily": {
@@ -878,7 +879,7 @@
           "textCase": "none"
         },
         "type": "typography",
-        "description": "Display 1. Custom element. Used for Splash Screens."
+        "description": "Display 1. Custom element. Used for Splash Screens"
       },
       "display-2": {
         "value": {
@@ -892,7 +893,7 @@
           "textCase": "none"
         },
         "type": "typography",
-        "description": "Display 2. Custom element. Used for Splash Screens."
+        "description": "Display 2. Custom element. Used for Splash Screens"
       }
     },
     "monospace": {
@@ -908,7 +909,7 @@
           "textCase": "none"
         },
         "type": "typography",
-        "description": "Monospace 1\nUsed for Global Status Bar clock."
+        "description": "Monospace 1. Used for Global Status Bar clock"
       }
     },
     "spacing": {
@@ -981,61 +982,61 @@
           "default": {
             "value": "{color.palette.brightblue.900}",
             "type": "color",
-            "description": "The background color of base elements, like the app or popup menus."
+            "description": "Background color of base elements, like the app or popup menus"
           },
           "header": {
             "value": "{color.palette.darkblue.900}",
             "type": "color",
-            "description": "The background color for the header of base elements."
+            "description": "Background color for the header of base elements"
           },
           "hover": {
             "value": "{color.palette.brightblue.850}",
             "type": "color",
-            "description": "The background color of base elements, like popup menus, when they are hovered over."
+            "description": "Background color of base elements, like popup menus, when they are hovered over"
           },
           "selected": {
             "value": "{color.palette.darkblue.700}",
             "type": "color",
-            "description": "The background color of base elements, like popup menus, when they are selected."
+            "description": "Background color of base elements, like popup menus, when they are selected"
           }
         },
         "surface": {
           "default": {
             "value": "{color.palette.darkblue.800}",
             "type": "color",
-            "description": "The background color of surface elements, like panels or dialogs."
+            "description": "Background color of surface elements, like panels or dialogs"
           },
           "header": {
             "value": "{color.palette.darkblue.900}",
             "type": "color",
-            "description": "The background color for the header of surface elements, including dialogs and table headers."
+            "description": "Background color for the header of surface elements, including dialogs and table headers"
           },
           "hover": {
             "value": "{color.palette.brightblue.800}",
             "type": "color",
-            "description": "The background color of surface elements, like cards or table rows, when they are hovered over."
+            "description": "Background color of surface elements, like cards or table rows, when they are hovered over"
           },
           "selected": {
             "value": "{color.palette.darkblue.700}",
             "type": "color",
-            "description": "The background color of surface elements, like cards or table rows, when they are selected."
+            "description": "Background color of surface elements, like cards or table rows, when they are selected"
           }
         },
         "interactive": {
           "default": {
             "value": "{color.palette.brightblue.500}",
             "type": "color",
-            "description": "The primary color used for the backgrounds of interactive elements."
+            "description": "Primary color used for the backgrounds of interactive elements"
           },
           "hover": {
             "value": "{color.palette.brightblue.400}",
             "type": "color",
-            "description": "The hover color used for the backgrounds of interactive elements."
+            "description": "Hover color used for the backgrounds of interactive elements"
           },
           "muted": {
             "value": "{color.palette.brightblue.700}",
             "type": "color",
-            "description": "A muted version of the primary color used for the background of interactive elements that don't need to be as strong as the primary color."
+            "description": "Muted version of the primary color used for the background of interactive elements that don't need to be as strong as the primary color"
           }
         }
       },
@@ -1043,49 +1044,49 @@
         "primary": {
           "value": "{color.palette.neutral.000}",
           "type": "color",
-          "description": "The primary color used for text within the application."
+          "description": "Primary color used for text within the application"
         },
         "secondary": {
           "value": "{color.palette.grey.300}",
           "type": "color",
-          "description": "The color used for text when less emphasis is needed."
+          "description": "Color used for text when less emphasis is needed"
         },
         "placeholder": {
           "value": "{color.palette.grey.500}",
           "type": "color",
-          "description": "The text color used for placeholder text in input and form fields."
+          "description": "Text color used for placeholder text in input and form fields"
         },
         "inverse": {
           "value": "{color.palette.darkblue.950}",
           "type": "color",
-          "description": "The color used for text on reversed backgrounds."
+          "description": "Color used for text on reversed backgrounds"
         },
         "interactive": {
           "default": {
             "value": "{color.palette.brightblue.500}",
             "type": "color",
-            "description": "The primary color used for interactive text elements."
+            "description": "Primary color used for interactive text elements"
           },
           "hover": {
             "value": "{color.palette.brightblue.400}",
             "type": "color",
-            "description": "The hover color used for interactive text elements. "
+            "description": "Hover color used for interactive text elements"
           }
         },
         "white": {
           "value": "{color.palette.neutral.000}",
           "type": "color",
-          "description": "Text that is white across all themes. Used for classification and status banners that do not change color in various themes."
+          "description": "Text that is white across all themes. Used for classification and status banners that do not change color in various themes"
         },
         "black": {
           "value": "{color.palette.neutral.1000}",
           "type": "color",
-          "description": "Text that is black across all themes. Used for classification and status banners that do not change color in various themes."
+          "description": "Text that is black across all themes. Used for classification and status banners that do not change color in various themes"
         },
         "error": {
           "value": "{color.palette.red.500}",
           "type": "color",
-          "description": "The text color used for form error messages."
+          "description": "Text color used for form error messages"
         }
       },
       "border": {
@@ -1093,29 +1094,29 @@
           "default": {
             "value": "{color.palette.brightblue.500}",
             "type": "color",
-            "description": "The primary color used for the border of interactive elements."
+            "description": "Primary color used for the border of interactive elements"
           },
           "hover": {
             "value": "{color.palette.brightblue.400}",
             "type": "color",
-            "description": "The hover color used for the border of interactive elements."
+            "description": "Hover color used for the border of interactive elements"
           },
           "muted": {
             "value": "{color.palette.brightblue.700}",
             "type": "color",
-            "description": "A muted version of the primary color used for the border of interactive elements that don't need to be as strong as the primary color."
+            "description": "Muted version of the primary color used for the border of interactive elements that don't need to be as strong as the primary color"
           }
         },
         "error": {
           "value": "{color.palette.red.500}",
           "type": "color",
-          "description": "The border color used for form error borders."
+          "description": "Border color used for form error borders"
         },
         "focus": {
           "default": {
             "value": "{color.palette.pink.200}",
             "type": "color",
-            "description": "The color of a focused element's outline"
+            "description": "Color of a focused element's outline"
           }
         }
       },
@@ -1123,64 +1124,64 @@
         "critical": {
           "value": "{color.palette.red.500}",
           "type": "color",
-          "description": "The color used to indicate items with a Critical status. Critical, form error, alert, emergency, urgent."
+          "description": "Color used to indicate items with a Critical status. Critical, form error, alert, emergency, urgent"
         },
         "serious": {
           "value": "{color.palette.orange.500}",
           "type": "color",
-          "description": "The color used to indicate items with a Serious status. Serious, warning, error, needs attention."
+          "description": "Color used to indicate items with a Serious status. Serious, warning, error, needs attention"
         },
         "caution": {
           "value": "{color.palette.yellow.500}",
           "type": "color",
-          "description": "The color used to indicate items with a Caution status. Caution, unstable, unsatisfactory."
+          "description": "Color used to indicate items with a Caution status. Caution, unstable, unsatisfactory"
         },
         "normal": {
           "value": "{color.palette.green.500}",
           "type": "color",
-          "description": "The color used to indicate items with a Normal status. Normal, on, ok, fine, go, satisfactory, success."
+          "description": "Color used to indicate items with a Normal status. Normal, on, ok, fine, go, satisfactory, success"
         },
         "standby": {
           "value": "{color.palette.cyan.600}",
           "type": "color",
-          "description": "The color used to indicate items with a Standby status. Standby, available, enabled."
+          "description": "Color used to indicate items with a Standby status. Standby, available, enabled"
         },
         "off": {
           "value": "{color.palette.grey.500}",
           "type": "color",
-          "description": "The color used to indicate items with an Off status. Off, unavailable, disabled."
+          "description": "Color used to indicate items with an Off status. Off, unavailable, disabled"
         }
       },
       "classification": {
         "topsecretsci": {
           "value": "{color.palette.yellow.500}",
           "type": "color",
-          "description": "The color used to indicate the Top Secret//SCI classification."
+          "description": "Color used to indicate the Top Secret//SCI classification"
         },
         "topsecret": {
           "value": "{color.palette.orange.700}",
           "type": "color",
-          "description": "The color used to indicate the Top Secret classification."
+          "description": "Color used to indicate the Top Secret classification"
         },
         "secret": {
           "value": "{color.palette.red.700}",
           "type": "color",
-          "description": "The color used to indicate the Secret classification."
+          "description": "Color used to indicate the Secret classification"
         },
         "confidential": {
           "value": "{color.palette.blue.800}",
           "type": "color",
-          "description": "The color used to indicate the Confidential classification."
+          "description": "Color used to indicate the Confidential classification"
         },
         "cui": {
           "value": "{color.palette.violet.800}",
           "type": "color",
-          "description": "The color used to indicate the CUI classification."
+          "description": "Color used to indicate the CUI classification"
         },
         "unclassified": {
           "value": "{color.palette.green.800}",
           "type": "color",
-          "description": "The color used to indicate the Unclassified classification."
+          "description": "Color used to indicate the Unclassified classification"
         }
       }
     },
@@ -1188,7 +1189,7 @@
       "disabled": {
         "value": "{opacity.40}",
         "type": "opacity",
-        "description": "Used to represent disabled state"
+        "description": "Opacity used to indicate the disabled state"
       }
     },
     "shadow": {
@@ -1212,7 +1213,7 @@
         "default": {
           "value": "{borderWidth.xs}",
           "type": "borderWidth",
-          "description": "The thickness of a focused element's outline"
+          "description": "Thickness of a focused element's outline"
         }
       }
     },
@@ -1221,7 +1222,7 @@
         "default": {
           "value": "{spacing.050}",
           "type": "spacing",
-          "description": "The amount of space between a focused element's outline and edge."
+          "description": "Space between a focused element's outline and edge"
         }
       }
     }
@@ -1233,12 +1234,12 @@
           "default": {
             "value": "{color.text.interactive.default}",
             "type": "color",
-            "description": "The color used for links in default state."
+            "description": "Color used for links in default state"
           },
           "hover": {
             "value": "{link.color.text.default}",
             "type": "color",
-            "description": "The color used for links in hover state. Links do not change color on hover."
+            "description": "Color used for links in hover state. Links do not change color on hover"
           }
         }
       }
@@ -1248,7 +1249,7 @@
         "border": {
           "value": "{color.palette.grey.700}",
           "type": "color",
-          "description": "The border color used for the Card component."
+          "description": "Border color used for the Card component"
         }
       }
     },
@@ -1257,7 +1258,7 @@
         "border": {
           "value": "{color.palette.neutral.1000}",
           "type": "color",
-          "description": "The border color used for the Container component."
+          "description": "Border color used for the Container component"
         }
       }
     },
@@ -1267,32 +1268,32 @@
           "topsecretsci": {
             "value": "{color.classification.topsecretsci}",
             "type": "color",
-            "description": "The background color of the Top Secret//SCI classification banner."
+            "description": "Background color of the Top Secret//SCI classification banner"
           },
           "topsecret": {
             "value": "{color.classification.topsecret}",
             "type": "color",
-            "description": "The background color of the Top Secret classification banner."
+            "description": "Background color of the Top Secret classification banner"
           },
           "secret": {
             "value": "{color.classification.secret}",
             "type": "color",
-            "description": "The background color of the Secret classification banner."
+            "description": "Background color of the Secret classification banner"
           },
           "confidential": {
             "value": "{color.classification.confidential}",
             "type": "color",
-            "description": "The background color of the Confidential classification banner."
+            "description": "Background color of the Confidential classification banner"
           },
           "cui": {
             "value": "{color.classification.cui}",
             "type": "color",
-            "description": "The background color of the CUI classification banner."
+            "description": "Background color of the CUI classification banner"
           },
           "unclassified": {
             "value": "{color.classification.unclassified}",
             "type": "color",
-            "description": "The background color of the Unclassified classification banner."
+            "description": "Background color of the Unclassified classification banner"
           }
         }
       }
@@ -1304,72 +1305,72 @@
             "on-dark": {
               "value": "{color.palette.red.500}",
               "type": "color",
-              "description": "The fill color of the Critical status symbol on a dark background."
+              "description": "Fill color of the Critical status symbol on a dark background"
             },
             "on-light": {
               "value": "{color.palette.red.600}",
               "type": "color",
-              "description": "The fill color of the Critical status symbol on a light background."
+              "description": "Fill color of the Critical status symbol on a light background"
             }
           },
           "serious": {
             "on-dark": {
               "value": "{color.palette.orange.500}",
               "type": "color",
-              "description": "The fill color of the Serious status symbol on a dark background."
+              "description": "Fill color of the Serious status symbol on a dark background"
             },
             "on-light": {
               "value": "{color.palette.orange.600}",
               "type": "color",
-              "description": "The fill color of the Serious status symbol on a light background."
+              "description": "Fill color of the Serious status symbol on a light background"
             }
           },
           "caution": {
             "on-dark": {
               "value": "{color.palette.yellow.500}",
               "type": "color",
-              "description": "The fill color of the Caution status symbol on a dark background."
+              "description": "Fill color of the Caution status symbol on a dark background"
             },
             "on-light": {
               "value": "{color.palette.yellow.600}",
               "type": "color",
-              "description": "The fill color of the Caution status symbol on a light background."
+              "description": "Fill color of the Caution status symbol on a light background"
             }
           },
           "normal": {
             "on-dark": {
               "value": "{color.palette.green.500}",
               "type": "color",
-              "description": "The fill color of the Normal status symbol on a dark background."
+              "description": "Fill color of the Normal status symbol on a dark background"
             },
             "on-light": {
               "value": "{color.palette.green.600}",
               "type": "color",
-              "description": "The fill color of the Normal status symbol on a light background."
+              "description": "Fill color of the Normal status symbol on a light background"
             }
           },
           "standby": {
             "on-dark": {
               "value": "{color.palette.cyan.600}",
               "type": "color",
-              "description": "The fill color of the Standby status symbol on a dark background."
+              "description": "Fill color of the Standby status symbol on a dark background"
             },
             "on-light": {
               "value": "{color.palette.cyan.500}",
               "type": "color",
-              "description": "The fill color of the Standby status symbol on a light background."
+              "description": "Fill color of the Standby status symbol on a light background"
             }
           },
           "off": {
             "on-dark": {
               "value": "{color.palette.grey.500}",
               "type": "color",
-              "description": "The fill color of the Off status symbol on a dark background."
+              "description": "Fill color of the Off status symbol on a dark background"
             },
             "on-light": {
               "value": "{color.palette.grey.600}",
               "type": "color",
-              "description": "The fill color of the Off status symbol on a light background."
+              "description": "Fill color of the Off status symbol on a light background"
             }
           }
         },
@@ -1377,32 +1378,32 @@
           "critical": {
             "value": "{color.palette.red.900}",
             "type": "color",
-            "description": "The border color of the Critical status symbol on light backgrounds."
+            "description": "Border color of the Critical status symbol on light backgrounds"
           },
           "serious": {
             "value": "{color.palette.orange.900}",
             "type": "color",
-            "description": "The border color of the Serious status symbol on light backgrounds."
+            "description": "Border color of the Serious status symbol on light backgrounds"
           },
           "caution": {
             "value": "{color.palette.yellow.900}",
             "type": "color",
-            "description": "The border color of the Caution status symbol on light backgrounds."
+            "description": "Border color of the Caution status symbol on light backgrounds"
           },
           "normal": {
             "value": "{color.palette.green.900}",
             "type": "color",
-            "description": "The border color of the Normal status symbol on light backgrounds."
+            "description": "Border color of the Normal status symbol on light backgrounds"
           },
           "standby": {
             "value": "{color.palette.cyan.900}",
             "type": "color",
-            "description": "The border color of the Standby status symbol on light backgrounds."
+            "description": "Border color of the Standby status symbol on light backgrounds"
           },
           "off": {
             "value": "{color.palette.grey.800}",
             "type": "color",
-            "description": "The border color of the Off status symbol on light backgrounds."
+            "description": "Border color of the Off status symbol on light backgrounds"
           }
         }
       },
@@ -1410,12 +1411,12 @@
         "on-dark": {
           "value": "{borderWidth.none}",
           "type": "borderWidth",
-          "description": "The border width for status symbols on a dark background"
+          "description": "Border width for status symbols on a dark background"
         },
         "on-light": {
           "value": "{borderWidth.xs}",
           "type": "borderWidth",
-          "description": "The border width for status symbols on a light background"
+          "description": "Border width for status symbols on a light background"
         }
       }
     },
@@ -1426,12 +1427,12 @@
             "default": {
               "value": "{color.palette.brightblue.500}",
               "type": "color",
-              "description": "The primary color used for interactive elements in the Global Status Bar."
+              "description": "Primary color used for interactive elements in the Global Status Bar"
             },
             "hover": {
               "value": "{color.palette.brightblue.400}",
               "type": "color",
-              "description": "The hover color used for interactive elements in the Global Status Bar."
+              "description": "Hover color used for interactive elements in the Global Status Bar"
             }
           }
         }
@@ -1440,12 +1441,12 @@
         "background": {
           "value": "{color.palette.darkblue.900}",
           "type": "color",
-          "description": "The background color of the Global Status Bar component. "
+          "description": "Background color of the Global Status Bar component"
         },
         "text": {
           "value": "{color.palette.neutral.000}",
           "type": "color",
-          "description": "The primary text color used within the Global Status Bar."
+          "description": "Primary text color used within the Global Status Bar"
         }
       }
     },
@@ -1454,7 +1455,7 @@
         "background-track": {
           "value": "1px",
           "type": "borderRadius",
-          "description": "The background track border radius"
+          "description": "Background track border radius"
         }
       }
     },
@@ -1462,7 +1463,7 @@
       "radius": {
         "value": "2px",
         "type": "borderRadius",
-        "description": "The checkbox border radius"
+        "description": "Checkbox border radius"
       }
     },
     "radio": {
@@ -1470,12 +1471,12 @@
         "inner": {
           "value": "4px",
           "type": "borderRadius",
-          "description": "The inside radio border radius"
+          "description": "Inside radio border radius"
         },
         "outer": {
           "value": "9px",
           "type": "borderRadius",
-          "description": "The outside radio border radius"
+          "description": "Outside radio border radius"
         }
       }
     },
@@ -1484,7 +1485,7 @@
         "track": {
           "value": "10px",
           "type": "borderRadius",
-          "description": "The switch track's border radius"
+          "description": "Switch track's border radius"
         }
       }
     },
@@ -1520,7 +1521,7 @@
       "radius": {
         "value": "4px",
         "type": "borderRadius",
-        "description": "The scrollbar's border radius"
+        "description": "Scrollbar's border radius"
       }
     },
     "progress": {
@@ -1528,12 +1529,12 @@
         "inner": {
           "value": "8px",
           "type": "borderRadius",
-          "description": "The inside border radius"
+          "description": "Inside border radius"
         },
         "outer": {
           "value": "10px",
           "type": "borderRadius",
-          "description": "The outside border radius"
+          "description": "Outside border radius"
         }
       }
     },
@@ -1584,12 +1585,12 @@
         "inner": {
           "value": "23px",
           "type": "borderRadius",
-          "description": "The inside border radius"
+          "description": "Inside border radius"
         },
         "outer": {
           "value": "30px",
           "type": "borderRadius",
-          "description": "The outside border radius"
+          "description": "Outside border radius"
         }
       }
     },
@@ -1598,12 +1599,12 @@
         "inner": {
           "value": "2px",
           "type": "borderRadius",
-          "description": "The inner radius of Notification Banner outlines."
+          "description": "Inner radius of Notification Banner outlines"
         },
         "outer": {
           "value": "{radius.base}",
           "type": "borderRadius",
-          "description": "The outer radius of Notification Banner outlines."
+          "description": "Outer radius of Notification Banner outlines"
         }
       },
       "color": {
@@ -1612,74 +1613,74 @@
             "normal": {
               "value": "{color.status.normal}",
               "type": "color",
-              "description": "The fill color of the Normal Notification Banner background."
+              "description": "Fill color of the Normal Notification Banner background"
             },
             "caution": {
               "value": "{color.status.caution}",
               "type": "color",
-              "description": "The fill color of the Caution Notification Banner background."
+              "description": "Fill color of the Caution Notification Banner background"
             },
             "serious": {
               "value": "{color.status.serious}",
               "type": "color",
-              "description": "The fill color of the Serious Notification Banner background."
+              "description": "Fill color of the Serious Notification Banner background"
             },
             "critical": {
               "value": "{color.status.critical}",
               "type": "color",
-              "description": "The fill color of the Critical Notification Banner background."
+              "description": "Fill color of the Critical Notification Banner background"
             },
             "standby": {
               "value": "{color.status.standby}",
               "type": "color",
-              "description": "The fill color of the Standby Notification Banner background."
+              "description": "Fill color of the Standby Notification Banner background"
             },
             "off": {
               "value": "{color.status.off}",
               "type": "color",
-              "description": "The fill color of the Off Notification Banner background."
+              "description": "Fill color of the Off Notification Banner background"
             },
             "default": {
               "value": "{color.border.interactive.default}",
               "type": "color",
-              "description": "The fill color of the Default Notification Banner background."
+              "description": "Fill color of the Default Notification Banner background"
             }
           },
           "outer": {
             "normal": {
               "value": "{color.status.normal}",
               "type": "color",
-              "description": "The stroke color of the Normal Notification Banner."
+              "description": "Stroke color of the Normal Notification Banner"
             },
             "caution": {
               "value": "{color.status.caution}",
               "type": "color",
-              "description": "The stroke color of the Caution Notification Banner."
+              "description": "Stroke color of the Caution Notification Banner"
             },
             "serious": {
               "value": "{color.status.serious}",
               "type": "color",
-              "description": "The stroke color of the Serious Notification Banner."
+              "description": "Stroke color of the Serious Notification Banner"
             },
             "critical": {
               "value": "{color.status.critical}",
               "type": "color",
-              "description": "The stroke color of the Critical Notification Banner."
+              "description": "Stroke color of the Critical Notification Banner"
             },
             "standby": {
               "value": "{color.status.standby}",
               "type": "color",
-              "description": "The stroke color of the Standby Notification Banner."
+              "description": "Stroke color of the Standby Notification Banner"
             },
             "off": {
               "value": "{color.status.off}",
               "type": "color",
-              "description": "The stroke color of the Off Notification Banner."
+              "description": "Stroke color of the Off Notification Banner"
             },
             "default": {
               "value": "{color.border.interactive.default}",
               "type": "color",
-              "description": "The stroke color of the Default Notification Banner."
+              "description": "Stroke color of the Default Notification Banner"
             }
           }
         }
@@ -1691,7 +1692,7 @@
           "fill": {
             "value": "{color.palette.grey.700}",
             "type": "color",
-            "description": "The fill color for menu dividers"
+            "description": "Fill color for menu dividers"
           }
         }
       }
@@ -1729,18 +1730,18 @@
         "background": {
           "value": "{color.palette.grey.800}",
           "type": "color",
-          "description": "The background color for Tooltips"
+          "description": "Background color for Tooltips"
         },
         "text": {
           "value": "{color.text.white}",
           "type": "color",
-          "description": "The text color for Tooltips"
+          "description": "Text color for Tooltips"
         }
       },
       "radius": {
         "value": "1px",
         "type": "borderRadius",
-        "description": "The tooltip border radius"
+        "description": "Tooltip border radius"
       }
     },
     "timeline": {
@@ -1769,61 +1770,61 @@
           "default": {
             "value": "{color.palette.neutral.000}",
             "type": "color",
-            "description": "The background color of surface elements, like panels or dialogs."
+            "description": "Background color of surface elements, like panels or dialogs"
           },
           "header": {
             "value": "{color.palette.grey.100}",
             "type": "color",
-            "description": "The background color for the header of surface elements, including dialogs and table headers."
+            "description": "Background color for the header of surface elements, including dialogs and table headers"
           },
           "selected": {
             "value": "{color.palette.brightblue.200}",
             "type": "color",
-            "description": "The background color of surface elements, like cards or table rows, when they are selected."
+            "description": "Background color of surface elements, like cards or table rows, when they are selected"
           },
           "hover": {
             "value": "{color.palette.brightblue.100}",
             "type": "color",
-            "description": "The background color of surface elements, like cards or table rows, when they are hovered over."
+            "description": "Background color of surface elements, like cards or table rows, when they are hovered over"
           }
         },
         "base": {
           "default": {
             "value": "{color.palette.grey.200}",
             "type": "color",
-            "description": "The background color of base elements, like the app or popup menus."
+            "description": "Background color of base elements, like the app or popup menus"
           },
           "header": {
             "value": "{color.palette.grey.100}",
             "type": "color",
-            "description": "The background color for the header of base elements."
+            "description": "Background color for the header of base elements"
           },
           "hover": {
             "value": "{color.palette.darkblue.200}",
             "type": "color",
-            "description": "The background color of base elements, like popup menus, when they are hovered over."
+            "description": "Background color of base elements, like popup menus, when they are hovered over"
           },
           "selected": {
             "value": "{color.palette.brightblue.200}",
             "type": "color",
-            "description": "The background color of base elements, like popup menus, when they are selected."
+            "description": "Background color of base elements, like popup menus, when they are selected"
           }
         },
         "interactive": {
           "default": {
             "value": "{color.palette.darkblue.500}",
             "type": "color",
-            "description": "The primary color used for the backgrounds of interactive elements."
+            "description": "Primary color used for the backgrounds of interactive elements"
           },
           "hover": {
             "value": "{color.palette.darkblue.600}",
             "type": "color",
-            "description": "The hover color used for the backgrounds of interactive elements."
+            "description": "Hover color used for the backgrounds of interactive elements"
           },
           "muted": {
             "value": "{color.palette.darkblue.400}",
             "type": "color",
-            "description": "A muted version of the primary color used for the background of interactive elements that don't need to be as strong as the primary color."
+            "description": "Muted version of the primary color used for the background of interactive elements that don't need to be as strong as the primary color"
           }
         }
       },
@@ -1831,39 +1832,39 @@
         "primary": {
           "value": "{color.palette.grey.900}",
           "type": "color",
-          "description": "The primary color used for text within the application."
+          "description": "Primary color used for text within the application"
         },
         "secondary": {
           "value": "{color.palette.grey.700}",
           "type": "color",
-          "description": "The color used for text when less emphasis is needed."
+          "description": "Color used for text when less emphasis is needed"
         },
         "placeholder": {
           "value": "{color.palette.grey.600}",
           "type": "color",
-          "description": "The text color used for placeholder text in input and form fields."
+          "description": "Text color used for placeholder text in input and form fields"
         },
         "inverse": {
           "value": "{color.palette.neutral.000}",
           "type": "color",
-          "description": "The color used for text on reversed backgrounds."
+          "description": "Color used for text on reversed backgrounds"
         },
         "interactive": {
           "default": {
             "value": "{color.palette.darkblue.500}",
             "type": "color",
-            "description": "The primary color used for interactive text elements."
+            "description": "Primary color used for interactive text elements"
           },
           "hover": {
             "value": "{color.palette.darkblue.600}",
             "type": "color",
-            "description": "The hover color used for interactive text elements. "
+            "description": "Hover color used for interactive text elements"
           }
         },
         "error": {
           "value": "{color.palette.red.700}",
           "type": "color",
-          "description": "The text color used for form error messages."
+          "description": "Text color used for form error messages"
         }
       },
       "border": {
@@ -1871,29 +1872,29 @@
           "default": {
             "value": "{color.palette.darkblue.500}",
             "type": "color",
-            "description": "The primary color used for the border of interactive elements."
+            "description": "Primary color used for the border of interactive elements"
           },
           "hover": {
             "value": "{color.palette.darkblue.600}",
             "type": "color",
-            "description": "The hover color used for the border of interactive elements."
+            "description": "Hover color used for the border of interactive elements"
           },
           "muted": {
             "value": "{color.palette.darkblue.400}",
             "type": "color",
-            "description": "A muted version of the primary color used for the border of interactive elements that don't need to be as strong as the primary color."
+            "description": "Muted version of the primary color used for the border of interactive elements that don't need to be as strong as the primary color"
           }
         },
         "error": {
           "value": "{color.palette.red.700}",
           "type": "color",
-          "description": "The border color used for form error borders."
+          "description": "Border color used for form error borders"
         },
         "focus": {
           "default": {
             "value": "{color.palette.pink.400}",
             "type": "color",
-            "description": "The color of a focused element's outline"
+            "description": "Color of a focused element's outline"
           }
         }
       },
@@ -1901,32 +1902,32 @@
         "critical": {
           "value": "{color.palette.red.600}",
           "type": "color",
-          "description": "The fill color of the Critical status symbol on a light background."
+          "description": "Fill color of the Critical status symbol on a light background"
         },
         "serious": {
           "value": "{color.palette.orange.600}",
           "type": "color",
-          "description": "The fill color of the Serious status symbol on a light background."
+          "description": "Fill color of the Serious status symbol on a light background"
         },
         "caution": {
           "value": "{color.palette.yellow.600}",
           "type": "color",
-          "description": "The fill color of the Caution status symbol on a light background."
+          "description": "Fill color of the Caution status symbol on a light background"
         },
         "normal": {
           "value": "{color.palette.green.600}",
           "type": "color",
-          "description": "The fill color of the Normal status symbol on a light background."
+          "description": "Fill color of the Normal status symbol on a light background"
         },
         "standby": {
           "value": "{color.palette.cyan.500}",
           "type": "color",
-          "description": "The fill color of the Standby status symbol on a light background."
+          "description": "Fill color of the Standby status symbol on a light background"
         },
         "off": {
           "value": "{color.palette.grey.600}",
           "type": "color",
-          "description": "The fill color of the Off status symbol on a light background."
+          "description": "Fill color of the Off status symbol on a light background"
         }
       }
     },
@@ -1983,12 +1984,12 @@
             "default": {
               "value": "{color.palette.brightblue.500}",
               "type": "color",
-              "description": "The primary color used for interactive elements in the Global Status Bar."
+              "description": "Primary color used for interactive elements in the Global Status Bar"
             },
             "hover": {
               "value": "{color.palette.brightblue.400}",
               "type": "color",
-              "description": "The hover color used for interactive elements in the Global Status Bar."
+              "description": "Hover color used for interactive elements in the Global Status Bar"
             }
           }
         }
@@ -1997,12 +1998,12 @@
         "background": {
           "value": "{color.palette.darkblue.900}",
           "type": "color",
-          "description": "The background color of the Global Status Bar component. "
+          "description": "Background color of the Global Status Bar component"
         },
         "text": {
           "value": "{color.palette.neutral.000}",
           "type": "color",
-          "description": "The primary text color used within the Global Status Bar."
+          "description": "Primary text color used within the Global Status Bar"
         }
       }
     },
@@ -2055,7 +2056,7 @@
             "normal": {
               "value": "{color.status.normal}",
               "type": "color",
-              "description": "The fill color of the Normal Notification Banner background."
+              "description": "Fill color of the Normal Notification Banner background"
             },
             "caution": {
               "value": "{color.status.caution}",
@@ -2120,12 +2121,12 @@
         "background": {
           "value": "{color.palette.grey.400}",
           "type": "color",
-          "description": "The background color for Tooltips"
+          "description": "Background color for Tooltips"
         },
         "text": {
           "value": "{color.text.black}",
           "type": "color",
-          "description": "The text color for Tooltips"
+          "description": "Text color for Tooltips"
         }
       }
     },
@@ -2282,61 +2283,61 @@
           "default": {
             "value": "{color.neutral.80}",
             "type": "color",
-            "description": "The background color of base elements, like the app or popup menus."
+            "description": "Background color of base elements, like the app or popup menus"
           },
           "header": {
             "value": "{color.neutral.40}",
             "type": "color",
-            "description": "The background color for the header of base elements."
+            "description": "Background color for the header of base elements"
           },
           "hover": {
             "value": "{color.neutral.200}",
             "type": "color",
-            "description": "The background color of base elements, like popup menus, when they are hovered over."
+            "description": "Background color of base elements, like popup menus, when they are hovered over"
           },
           "selected": {
             "value": "{color.neutral.80}",
             "type": "color",
-            "description": "The background color of base elements, like popup menus, when they are selected."
+            "description": "Background color of base elements, like popup menus, when they are selected"
           }
         },
         "surface": {
           "default": {
             "value": "{color.neutral.000}",
             "type": "color",
-            "description": "The background color of surface elements, like panels or dialogs."
+            "description": "Background color of surface elements, like panels or dialogs"
           },
           "header": {
             "value": "{color.neutral.40}",
             "type": "color",
-            "description": "The background color for the header of surface elements, including dialogs and table headers."
+            "description": "Background color for the header of surface elements, including dialogs and table headers"
           },
           "hover": {
             "value": "{color.neutral.80}",
             "type": "color",
-            "description": "The background color of surface elements, like cards or table rows, when they are hovered over."
+            "description": "Background color of surface elements, like cards or table rows, when they are hovered over"
           },
           "selected": {
             "value": "{color.neutral.120}",
             "type": "color",
-            "description": "The background color of surface elements, like cards or table rows, when they are selected."
+            "description": "Background color of surface elements, like cards or table rows, when they are selected"
           }
         },
         "interactive": {
           "default": {
             "value": "{color.neutral.800}",
             "type": "color",
-            "description": "The primary color used for the backgrounds of interactive elements."
+            "description": "Primary color used for the backgrounds of interactive elements"
           },
           "hover": {
             "value": "{color.neutral.680}",
             "type": "color",
-            "description": "The hover color used for the backgrounds of interactive elements."
+            "description": "Hover color used for the backgrounds of interactive elements"
           },
           "muted": {
             "value": "{color.neutral.480}",
             "type": "color",
-            "description": "A muted version of the primary color used for the background of interactive elements that don't need to be as strong as the primary color."
+            "description": "Muted version of the primary color used for the background of interactive elements that don't need to be as strong as the primary color"
           }
         }
       },
@@ -2344,49 +2345,49 @@
         "primary": {
           "value": "{color.neutral.920}",
           "type": "color",
-          "description": "The primary color used for text within the application."
+          "description": "Primary color used for text within the application"
         },
         "secondary": {
           "value": "{color.neutral.680}",
           "type": "color",
-          "description": "The color used for text when less emphasis is needed."
+          "description": "Color used for text when less emphasis is needed"
         },
         "placeholder": {
           "value": "{color.neutral.600}",
           "type": "color",
-          "description": "The text color used for placeholder text in input and form fields."
+          "description": "Text color used for placeholder text in input and form fields"
         },
         "inverse": {
           "value": "{color.neutral.000}",
           "type": "color",
-          "description": "The color used for text on reversed backgrounds."
+          "description": "Color used for text on reversed backgrounds"
         },
         "interactive": {
           "default": {
             "value": "{color.neutral.800}",
             "type": "color",
-            "description": "The primary color used for interactive text elements."
+            "description": "Primary color used for interactive text elements"
           },
           "hover": {
             "value": "{color.neutral.680}",
             "type": "color",
-            "description": "The hover color used for interactive text elements. "
+            "description": "Hover color used for interactive text elements"
           }
         },
         "white": {
           "value": "{color.palette.neutral.000}",
           "type": "color",
-          "description": "Text that is white across all themes. Used for classification and status banners that do not change color in various themes."
+          "description": "Text that is white across all themes. Used for classification and status banners that do not change color in various themes"
         },
         "black": {
           "value": "{color.palette.neutral.1000}",
           "type": "color",
-          "description": "Text that is black across all themes. Used for classification and status banners that do not change color in various themes."
+          "description": "Text that is black across all themes. Used for classification and status banners that do not change color in various themes"
         },
         "error": {
           "value": "{color.palette.red.700}",
           "type": "color",
-          "description": "The text color used for form error messages."
+          "description": "Text color used for form error messages"
         }
       },
       "border": {
@@ -2394,87 +2395,87 @@
           "default": {
             "value": "{color.neutral.800}",
             "type": "color",
-            "description": "The primary color used for the border of interactive elements."
+            "description": "Primary color used for the border of interactive elements"
           },
           "hover": {
             "value": "{color.neutral.760}",
             "type": "color",
-            "description": "The hover color used for the border of interactive elements."
+            "description": "Hover color used for the border of interactive elements"
           },
           "muted": {
             "value": "{color.neutral.480}",
             "type": "color",
-            "description": "A muted version of the primary color used for the border of interactive elements that don't need to be as strong as the primary color."
+            "description": "Muted version of the primary color used for the border of interactive elements that don't need to be as strong as the primary color"
           }
         },
         "error": {
           "value": "{color.palette.red.700}",
           "type": "color",
-          "description": "The border color used for form error borders."
+          "description": "Border color used for form error borders"
         }
       },
       "status": {
         "critical": {
           "value": "{color.neutral.280}",
           "type": "color",
-          "description": "The color used to indicate items with a Critical status. Critical, form error, alert, emergency, urgent."
+          "description": "Color used to indicate items with a Critical status. Critical, form error, alert, emergency, urgent"
         },
         "serious": {
           "value": "{color.neutral.200}",
           "type": "color",
-          "description": "The color used to indicate items with a Serious status. Serious, warning, error, needs attention."
+          "description": "Color used to indicate items with a Serious status. Serious, warning, error, needs attention"
         },
         "caution": {
           "value": "{color.neutral.40}",
           "type": "color",
-          "description": "The color used to indicate items with a Caution status. Caution, unstable, unsatisfactory."
+          "description": "Color used to indicate items with a Caution status. Caution, unstable, unsatisfactory"
         },
         "normal": {
           "value": "{color.neutral.120}",
           "type": "color",
-          "description": "The color used to indicate items with a Normal status. Normal, on, ok, fine, go, satisfactory, success."
+          "description": "Color used to indicate items with a Normal status. Normal, on, ok, fine, go, satisfactory, success"
         },
         "standby": {
           "value": "{color.neutral.160}",
           "type": "color",
-          "description": "The color used to indicate items with a Standby status. Standby, available, enabled."
+          "description": "Color used to indicate items with a Standby status. Standby, available, enabled"
         },
         "off": {
           "value": "{color.neutral.320}",
           "type": "color",
-          "description": "The color used to indicate items with an Off status. Off, unavailable, disabled."
+          "description": "Color used to indicate items with an Off status. Off, unavailable, disabled"
         }
       },
       "classification": {
         "topsecretsci": {
           "value": "{color.neutral.560}",
           "type": "color",
-          "description": "The color used to indicate the Top Secret//SCI classification."
+          "description": "Color used to indicate the Top Secret//SCI classification"
         },
         "topsecret": {
           "value": "{color.neutral.560}",
           "type": "color",
-          "description": "The color used to indicate the Top Secret classification."
+          "description": "Color used to indicate the Top Secret classification"
         },
         "secret": {
           "value": "{color.neutral.560}",
           "type": "color",
-          "description": "The color used to indicate the Secret classification."
+          "description": "Color used to indicate the Secret classification"
         },
         "confidential": {
           "value": "{color.neutral.560}",
           "type": "color",
-          "description": "The color used to indicate the Confidential classification."
+          "description": "Color used to indicate the Confidential classification"
         },
         "cui": {
           "value": "{color.neutral.560}",
           "type": "color",
-          "description": "The color used to indicate the CUI classification."
+          "description": "Color used to indicate the CUI classification"
         },
         "unclassified": {
           "value": "{color.neutral.560}",
           "type": "color",
-          "description": "The color used to indicate the Unclassified classification."
+          "description": "Color used to indicate the Unclassified classification"
         }
       }
     },
@@ -2482,7 +2483,7 @@
       "disabled": {
         "value": "{opacity.40}",
         "type": "opacity",
-        "description": "Used to represent disabled state"
+        "description": "Opacity used in disabled state"
       }
     },
     "shadow": {
@@ -2507,12 +2508,12 @@
           "default": {
             "value": "{color.text.interactive.default}",
             "type": "color",
-            "description": "The color used for links in default state."
+            "description": "Color used for links in default state"
           },
           "hover": {
             "value": "{link.color.text.default}",
             "type": "color",
-            "description": "The color used for links in hover state. Links do not change color on hover."
+            "description": "Color used for links in hover state. Links do not change color on hover"
           }
         }
       }
@@ -2522,7 +2523,7 @@
         "border": {
           "value": "{color.palette.grey.700}",
           "type": "color",
-          "description": "The border color used for the Card component."
+          "description": "Border color used for the Card component"
         }
       }
     },
@@ -2531,7 +2532,7 @@
         "border": {
           "value": "{color.palette.neutral.1000}",
           "type": "color",
-          "description": "The border color used for the Container component."
+          "description": "Border color used for the Container component"
         }
       }
     },
@@ -2541,32 +2542,32 @@
           "topsecretsci": {
             "value": "{color.classification.topsecretsci}",
             "type": "color",
-            "description": "The background color of the Top Secret//SCI classification banner."
+            "description": "Background color of the Top Secret//SCI classification banner"
           },
           "topsecret": {
             "value": "{color.classification.topsecret}",
             "type": "color",
-            "description": "The background color of the Top Secret classification banner."
+            "description": "Background color of the Top Secret classification banner"
           },
           "secret": {
             "value": "{color.classification.secret}",
             "type": "color",
-            "description": "The background color of the Secret classification banner."
+            "description": "Background color of the Secret classification banner"
           },
           "confidential": {
             "value": "{color.classification.confidential}",
             "type": "color",
-            "description": "The background color of the Confidential classification banner."
+            "description": "Background color of the Confidential classification banner"
           },
           "cui": {
             "value": "{color.classification.cui}",
             "type": "color",
-            "description": "The background color of the CUI classification banner."
+            "description": "Background color of the CUI classification banner"
           },
           "unclassified": {
             "value": "{color.classification.unclassified}",
             "type": "color",
-            "description": "The background color of the Unclassified classification banner."
+            "description": "Background color of the Unclassified classification banner"
           }
         }
       }
@@ -2578,72 +2579,72 @@
             "on-dark": {
               "value": "{color.status.critical}",
               "type": "color",
-              "description": "The fill color of the Critical status symbol on a dark background."
+              "description": "Fill color of the Critical status symbol on a dark background"
             },
             "on-light": {
               "value": "{color.status.critical}",
               "type": "color",
-              "description": "The fill color of the Critical status symbol on a light background."
+              "description": "Fill color of the Critical status symbol on a light background"
             }
           },
           "serious": {
             "on-dark": {
               "value": "{color.status.serious}",
               "type": "color",
-              "description": "The fill color of the Serious status symbol on a dark background."
+              "description": "Fill color of the Serious status symbol on a dark background"
             },
             "on-light": {
               "value": "{color.status.serious}",
               "type": "color",
-              "description": "The fill color of the Serious status symbol on a light background."
+              "description": "Fill color of the Serious status symbol on a light background"
             }
           },
           "caution": {
             "on-dark": {
               "value": "{color.status.caution}",
               "type": "color",
-              "description": "The fill color of the Caution status symbol on a dark background."
+              "description": "Fill color of the Caution status symbol on a dark background"
             },
             "on-light": {
               "value": "{color.status.caution}",
               "type": "color",
-              "description": "The fill color of the Caution status symbol on a light background."
+              "description": "Fill color of the Caution status symbol on a light background"
             }
           },
           "normal": {
             "on-dark": {
               "value": "{color.status.normal}",
               "type": "color",
-              "description": "The fill color of the Normal status symbol on a dark background."
+              "description": "Fill color of the Normal status symbol on a dark background"
             },
             "on-light": {
               "value": "{color.status.normal}",
               "type": "color",
-              "description": "The fill color of the Normal status symbol on a light background."
+              "description": "Fill color of the Normal status symbol on a light background"
             }
           },
           "standby": {
             "on-dark": {
               "value": "{color.status.standby}",
               "type": "color",
-              "description": "The fill color of the Standby status symbol on a dark background."
+              "description": "Fill color of the Standby status symbol on a dark background"
             },
             "on-light": {
               "value": "{color.status.standby}",
               "type": "color",
-              "description": "The fill color of the Standby status symbol on a light background."
+              "description": "Fill color of the Standby status symbol on a light background"
             }
           },
           "off": {
             "on-dark": {
               "value": "{color.status.off}",
               "type": "color",
-              "description": "The fill color of the Off status symbol on a dark background."
+              "description": "Fill color of the Off status symbol on a dark background"
             },
             "on-light": {
               "value": "{color.status.off}",
               "type": "color",
-              "description": "The fill color of the Off status symbol on a light background."
+              "description": "Fill color of the Off status symbol on a light background"
             }
           }
         },
@@ -2651,32 +2652,32 @@
           "critical": {
             "value": "{color.neutral.760}",
             "type": "color",
-            "description": "The border color of the Critical status symbol on light backgrounds."
+            "description": "Border color of the Critical status symbol on light backgrounds"
           },
           "serious": {
             "value": "{color.neutral.760}",
             "type": "color",
-            "description": "The border color of the Serious status symbol on light backgrounds."
+            "description": "Border color of the Serious status symbol on light backgrounds"
           },
           "caution": {
             "value": "{color.neutral.800}",
             "type": "color",
-            "description": "The border color of the Caution status symbol on light backgrounds."
+            "description": "Border color of the Caution status symbol on light backgrounds"
           },
           "normal": {
             "value": "{color.neutral.840}",
             "type": "color",
-            "description": "The border color of the Normal status symbol on light backgrounds."
+            "description": "Border color of the Normal status symbol on light backgrounds"
           },
           "standby": {
             "value": "{color.neutral.720}",
             "type": "color",
-            "description": "The border color of the Standby status symbol on light backgrounds."
+            "description": "Border color of the Standby status symbol on light backgrounds"
           },
           "off": {
             "value": "{color.neutral.760}",
             "type": "color",
-            "description": "The border color of the Off status symbol on light backgrounds."
+            "description": "Border color of the Off status symbol on light backgrounds"
           }
         }
       },
@@ -2684,12 +2685,12 @@
         "on-dark": {
           "value": "{borderWidth.none}",
           "type": "borderWidth",
-          "description": "The border width for status symbols on a dark background"
+          "description": "Border width for status symbols on a dark background"
         },
         "on-light": {
           "value": "{borderWidth.xs}",
           "type": "borderWidth",
-          "description": "The border width for status symbols on a light background"
+          "description": "Border width for status symbols on a light background"
         }
       }
     },
@@ -2700,12 +2701,12 @@
             "default": {
               "value": "{color.neutral.480}",
               "type": "color",
-              "description": "The primary color used for interactive elements in the Global Status Bar."
+              "description": "Primary color used for interactive elements in the Global Status Bar"
             },
             "hover": {
               "value": "{color.neutral.840}",
               "type": "color",
-              "description": "The hover color used for interactive elements in the Global Status Bar."
+              "description": "Hover color used for interactive elements in the Global Status Bar"
             }
           }
         }
@@ -2714,12 +2715,12 @@
         "background": {
           "value": "{color.neutral.880}",
           "type": "color",
-          "description": "The background color of the Global Status Bar component. "
+          "description": "Background color of the Global Status Bar component"
         },
         "text": {
           "value": "{color.palette.neutral.000}",
           "type": "color",
-          "description": "The primary text color used within the Global Status Bar."
+          "description": "Primary text color used within the Global Status Bar"
         }
       }
     },
@@ -2728,7 +2729,7 @@
         "background-track": {
           "value": "1px",
           "type": "borderRadius",
-          "description": "The background track border radius"
+          "description": "Background track border radius"
         }
       }
     },
@@ -2736,7 +2737,7 @@
       "radius": {
         "value": "2px",
         "type": "borderRadius",
-        "description": "The checkbox border radius"
+        "description": "Checkbox border radius"
       }
     },
     "radio": {
@@ -2744,12 +2745,12 @@
         "inner": {
           "value": "4px",
           "type": "borderRadius",
-          "description": "The inside radio border radius"
+          "description": "Inside radio border radius"
         },
         "outer": {
           "value": "9px",
           "type": "borderRadius",
-          "description": "The outside radio border radius"
+          "description": "Outside radio border radius"
         }
       }
     },
@@ -2758,7 +2759,7 @@
         "track": {
           "value": "10px",
           "type": "borderRadius",
-          "description": "The switch track's border radius"
+          "description": "Switch track's border radius"
         }
       }
     },
@@ -2794,7 +2795,7 @@
       "radius": {
         "value": "4px",
         "type": "borderRadius",
-        "description": "The scrollbar's border radius"
+        "description": "Scrollbar's border radius"
       }
     },
     "progress": {
@@ -2802,12 +2803,12 @@
         "inner": {
           "value": "8px",
           "type": "borderRadius",
-          "description": "The inside border radius"
+          "description": "Inside border radius"
         },
         "outer": {
           "value": "10px",
           "type": "borderRadius",
-          "description": "The outside border radius"
+          "description": "Outside border radius"
         }
       }
     },
@@ -2858,12 +2859,12 @@
         "inner": {
           "value": "23px",
           "type": "borderRadius",
-          "description": "The inside border radius"
+          "description": "Inside border radius"
         },
         "outer": {
           "value": "30px",
           "type": "borderRadius",
-          "description": "The outside border radius"
+          "description": "Outside border radius"
         }
       }
     },
@@ -2872,12 +2873,12 @@
         "inner": {
           "value": "2px",
           "type": "borderRadius",
-          "description": "The inner radius of Notification Banner outlines."
+          "description": "Inner radius of Notification Banner outlines"
         },
         "outer": {
           "value": "{radius.base}",
           "type": "borderRadius",
-          "description": "The outer radius of Notification Banner outlines."
+          "description": "Outer radius of Notification Banner outlines"
         }
       },
       "color": {
@@ -2886,74 +2887,74 @@
             "normal": {
               "value": "{color.status.normal}",
               "type": "color",
-              "description": "The fill color of the Normal Notification Banner background."
+              "description": "Fill color of the Normal Notification Banner background"
             },
             "caution": {
               "value": "{color.status.caution}",
               "type": "color",
-              "description": "The fill color of the Caution Notification Banner background."
+              "description": "Fill color of the Caution Notification Banner background"
             },
             "serious": {
               "value": "{color.status.serious}",
               "type": "color",
-              "description": "The fill color of the Serious Notification Banner background."
+              "description": "Fill color of the Serious Notification Banner background"
             },
             "critical": {
               "value": "{color.status.critical}",
               "type": "color",
-              "description": "The fill color of the Critical Notification Banner background."
+              "description": "Fill color of the Critical Notification Banner background"
             },
             "standby": {
               "value": "{color.status.standby}",
               "type": "color",
-              "description": "The fill color of the Standby Notification Banner background."
+              "description": "Fill color of the Standby Notification Banner background"
             },
             "off": {
               "value": "{color.status.off}",
               "type": "color",
-              "description": "The fill color of the Off Notification Banner background."
+              "description": "Fill color of the Off Notification Banner background"
             },
             "default": {
               "value": "{color.neutral.280}",
               "type": "color",
-              "description": "The fill color of the Default Notification Banner background."
+              "description": "Fill color of the Default Notification Banner background"
             }
           },
           "outer": {
             "normal": {
               "value": "{status-symbol.color.border.normal}",
               "type": "color",
-              "description": "The stroke color of the Normal Notification Banner."
+              "description": "Stroke color of the Normal Notification Banner"
             },
             "caution": {
               "value": "{status-symbol.color.border.caution}",
               "type": "color",
-              "description": "The stroke color of the Caution Notification Banner.\n"
+              "description": "Stroke color of the Caution Notification Banner.\n"
             },
             "serious": {
               "value": "{status-symbol.color.border.serious}",
               "type": "color",
-              "description": "The stroke color of the Serious Notification Banner."
+              "description": "Stroke color of the Serious Notification Banner"
             },
             "critical": {
               "value": "{status-symbol.color.border.critical}",
               "type": "color",
-              "description": "The stroke color of the Critical Notification Banner."
+              "description": "Stroke color of the Critical Notification Banner"
             },
             "standby": {
               "value": "{status-symbol.color.border.standby}",
               "type": "color",
-              "description": "The stroke color of the Standby Notification Banner."
+              "description": "Stroke color of the Standby Notification Banner"
             },
             "off": {
               "value": "{status-symbol.color.border.off}",
               "type": "color",
-              "description": "The stroke color of the Off Notification Banner."
+              "description": "Stroke color of the Off Notification Banner"
             },
             "default": {
               "value": "{color.neutral.760}",
               "type": "color",
-              "description": "The stroke color of the Default Notification Banner."
+              "description": "Stroke color of the Default Notification Banner"
             }
           }
         }
@@ -2965,7 +2966,7 @@
           "fill": {
             "value": "{color.palette.grey.700}",
             "type": "color",
-            "description": "The fill color for menu dividers"
+            "description": "Fill color for menu dividers"
           }
         }
       }
@@ -3013,7 +3014,7 @@
           "background": {
             "value": "{color.neutral.400}",
             "type": "color",
-            "description": "Background color style for the timeline cell."
+            "description": "Background color style for the timeline cell"
           }
         }
       }
@@ -3024,12 +3025,12 @@
           "default": {
             "value": "{color.neutral.800}",
             "type": "color",
-            "description": "The background color used for the default state of the Push Button component."
+            "description": "Background color used for the default state of the Push Button component"
           },
           "hover": {
             "value": "{color.neutral.680}",
             "type": "color",
-            "description": "The background color used for the hover state of the Push Button component."
+            "description": "Background color used for the hover state of the Push Button component"
           }
         }
       }

--- a/dist/json/docs-light.json
+++ b/dist/json/docs-light.json
@@ -769,7 +769,7 @@
   {
     "name": "opacity-disabled",
     "value": "40%",
-    "description": "Opacity used in disabled state",
+    "description": "Opacity used to indicate the disabled state",
     "property": "disabled",
     "category": "opacity",
     "component": null,

--- a/dist/json/docs-light.json
+++ b/dist/json/docs-light.json
@@ -2,7 +2,7 @@
   {
     "name": "link-color-text-default",
     "value": "#4dacff",
-    "description": "The color used for links in default state.",
+    "description": "Color used for links in default state",
     "property": "text",
     "category": "color",
     "component": "link",
@@ -12,7 +12,7 @@
   {
     "name": "link-color-text-hover",
     "value": "#4dacff",
-    "description": "The color used for links in hover state. Links do not change color on hover.",
+    "description": "Color used for links in hover state. Links do not change color on hover",
     "property": "text",
     "category": "color",
     "component": "link",
@@ -22,7 +22,7 @@
   {
     "name": "card-color-border",
     "value": "#51555b",
-    "description": "The border color used for the Card component.",
+    "description": "Border color used for the Card component",
     "property": "border",
     "category": "color",
     "component": "card",
@@ -42,7 +42,7 @@
   {
     "name": "classification-banner-color-background-topsecretsci",
     "value": "#fce83a",
-    "description": "The background color of the Top Secret//SCI classification banner.",
+    "description": "Background color of the Top Secret//SCI classification banner",
     "property": "background",
     "category": "color",
     "component": "classification-banner",
@@ -52,7 +52,7 @@
   {
     "name": "classification-banner-color-background-topsecret",
     "value": "#ff8c00",
-    "description": "The background color of the Top Secret classification banner.",
+    "description": "Background color of the Top Secret classification banner",
     "property": "background",
     "category": "color",
     "component": "classification-banner",
@@ -62,7 +62,7 @@
   {
     "name": "classification-banner-color-background-secret",
     "value": "#c8102e",
-    "description": "The background color of the Secret classification banner.",
+    "description": "Background color of the Secret classification banner",
     "property": "background",
     "category": "color",
     "component": "classification-banner",
@@ -72,7 +72,7 @@
   {
     "name": "classification-banner-color-background-confidential",
     "value": "#0033a0",
-    "description": "The background color of the Confidential classification banner.",
+    "description": "Background color of the Confidential classification banner",
     "property": "background",
     "category": "color",
     "component": "classification-banner",
@@ -82,7 +82,7 @@
   {
     "name": "classification-banner-color-background-cui",
     "value": "#502b85",
-    "description": "The background color of the CUI classification banner.",
+    "description": "Background color of the CUI classification banner",
     "property": "background",
     "category": "color",
     "component": "classification-banner",
@@ -92,7 +92,7 @@
   {
     "name": "classification-banner-color-background-unclassified",
     "value": "#007a33",
-    "description": "The background color of the Unclassified classification banner.",
+    "description": "Background color of the Unclassified classification banner",
     "property": "background",
     "category": "color",
     "component": "classification-banner",
@@ -102,7 +102,7 @@
   {
     "name": "status-symbol-color-fill-critical-on-dark",
     "value": "#ff3838",
-    "description": "The fill color of the Critical status symbol on a dark background.",
+    "description": "Fill color of the Critical status symbol on a dark background",
     "property": "fill",
     "category": "color",
     "component": "status-symbol",
@@ -112,7 +112,7 @@
   {
     "name": "status-symbol-color-fill-critical-on-light",
     "value": "#ff2a04",
-    "description": "The fill color of the Critical status symbol on a light background.",
+    "description": "Fill color of the Critical status symbol on a light background",
     "property": "fill",
     "category": "color",
     "component": "status-symbol",
@@ -122,7 +122,7 @@
   {
     "name": "status-symbol-color-fill-serious-on-dark",
     "value": "#ffb302",
-    "description": "The fill color of the Serious status symbol on a dark background.",
+    "description": "Fill color of the Serious status symbol on a dark background",
     "property": "fill",
     "category": "color",
     "component": "status-symbol",
@@ -132,7 +132,7 @@
   {
     "name": "status-symbol-color-fill-serious-on-light",
     "value": "#ffaf3d",
-    "description": "The fill color of the Serious status symbol on a light background.",
+    "description": "Fill color of the Serious status symbol on a light background",
     "property": "fill",
     "category": "color",
     "component": "status-symbol",
@@ -142,7 +142,7 @@
   {
     "name": "status-symbol-color-fill-caution-on-dark",
     "value": "#fce83a",
-    "description": "The fill color of the Caution status symbol on a dark background.",
+    "description": "Fill color of the Caution status symbol on a dark background",
     "property": "fill",
     "category": "color",
     "component": "status-symbol",
@@ -152,7 +152,7 @@
   {
     "name": "status-symbol-color-fill-caution-on-light",
     "value": "#fad800",
-    "description": "The fill color of the Caution status symbol on a light background.",
+    "description": "Fill color of the Caution status symbol on a light background",
     "property": "fill",
     "category": "color",
     "component": "status-symbol",
@@ -162,7 +162,7 @@
   {
     "name": "status-symbol-color-fill-normal-on-dark",
     "value": "#56f000",
-    "description": "The fill color of the Normal status symbol on a dark background.",
+    "description": "Fill color of the Normal status symbol on a dark background",
     "property": "fill",
     "category": "color",
     "component": "status-symbol",
@@ -172,7 +172,7 @@
   {
     "name": "status-symbol-color-fill-normal-on-light",
     "value": "#00e200",
-    "description": "The fill color of the Normal status symbol on a light background.",
+    "description": "Fill color of the Normal status symbol on a light background",
     "property": "fill",
     "category": "color",
     "component": "status-symbol",
@@ -182,7 +182,7 @@
   {
     "name": "status-symbol-color-fill-standby-on-dark",
     "value": "#2dccff",
-    "description": "The fill color of the Standby status symbol on a dark background.",
+    "description": "Fill color of the Standby status symbol on a dark background",
     "property": "fill",
     "category": "color",
     "component": "status-symbol",
@@ -192,7 +192,7 @@
   {
     "name": "status-symbol-color-fill-standby-on-light",
     "value": "#64d9ff",
-    "description": "The fill color of the Standby status symbol on a light background.",
+    "description": "Fill color of the Standby status symbol on a light background",
     "property": "fill",
     "category": "color",
     "component": "status-symbol",
@@ -202,7 +202,7 @@
   {
     "name": "status-symbol-color-fill-off-on-dark",
     "value": "#a4abb6",
-    "description": "The fill color of the Off status symbol on a dark background.",
+    "description": "Fill color of the Off status symbol on a dark background",
     "property": "fill",
     "category": "color",
     "component": "status-symbol",
@@ -212,7 +212,7 @@
   {
     "name": "status-symbol-color-fill-off-on-light",
     "value": "#7b8089",
-    "description": "The fill color of the Off status symbol on a light background.",
+    "description": "Fill color of the Off status symbol on a light background",
     "property": "fill",
     "category": "color",
     "component": "status-symbol",
@@ -222,7 +222,7 @@
   {
     "name": "status-symbol-color-border-critical",
     "value": "#661102",
-    "description": "The border color of the Critical status symbol on light backgrounds.",
+    "description": "Border color of the Critical status symbol on light backgrounds",
     "property": "border",
     "category": "color",
     "component": "status-symbol",
@@ -232,7 +232,7 @@
   {
     "name": "status-symbol-color-border-serious",
     "value": "#664618",
-    "description": "The border color of the Serious status symbol on light backgrounds.",
+    "description": "Border color of the Serious status symbol on light backgrounds",
     "property": "border",
     "category": "color",
     "component": "status-symbol",
@@ -242,7 +242,7 @@
   {
     "name": "status-symbol-color-border-caution",
     "value": "#645600",
-    "description": "The border color of the Caution status symbol on light backgrounds.",
+    "description": "Border color of the Caution status symbol on light backgrounds",
     "property": "border",
     "category": "color",
     "component": "status-symbol",
@@ -252,7 +252,7 @@
   {
     "name": "status-symbol-color-border-normal",
     "value": "#005a00",
-    "description": "The border color of the Normal status symbol on light backgrounds.",
+    "description": "Border color of the Normal status symbol on light backgrounds",
     "property": "border",
     "category": "color",
     "component": "status-symbol",
@@ -262,7 +262,7 @@
   {
     "name": "status-symbol-color-border-standby",
     "value": "#285766",
-    "description": "The border color of the Standby status symbol on light backgrounds.",
+    "description": "Border color of the Standby status symbol on light backgrounds",
     "property": "border",
     "category": "color",
     "component": "status-symbol",
@@ -272,7 +272,7 @@
   {
     "name": "status-symbol-color-border-off",
     "value": "#3c3e42",
-    "description": "The border color of the Off status symbol on light backgrounds.",
+    "description": "Border color of the Off status symbol on light backgrounds",
     "property": "border",
     "category": "color",
     "component": "status-symbol",
@@ -282,7 +282,7 @@
   {
     "name": "status-symbol-border-width-on-dark",
     "value": 0,
-    "description": "The border width for status symbols on a dark background",
+    "description": "Border width for status symbols on a dark background",
     "property": "on-dark",
     "category": "borderWidth",
     "component": "status-symbol",
@@ -292,7 +292,7 @@
   {
     "name": "status-symbol-border-width-on-light",
     "value": "1px",
-    "description": "The border width for status symbols on a light background",
+    "description": "Border width for status symbols on a light background",
     "property": "on-light",
     "category": "borderWidth",
     "component": "status-symbol",
@@ -302,7 +302,7 @@
   {
     "name": "gsb-icon-color-fill-default",
     "value": "#4dacff",
-    "description": "The primary color used for interactive elements in the Global Status Bar.",
+    "description": "Primary color used for interactive elements in the Global Status Bar",
     "property": "icon",
     "category": "color",
     "component": "gsb",
@@ -312,7 +312,7 @@
   {
     "name": "gsb-icon-color-fill-hover",
     "value": "#92cbff",
-    "description": "The hover color used for interactive elements in the Global Status Bar.",
+    "description": "Hover color used for interactive elements in the Global Status Bar",
     "property": "icon",
     "category": "color",
     "component": "gsb",
@@ -322,7 +322,7 @@
   {
     "name": "gsb-color-background",
     "value": "#172635",
-    "description": "The background color of the Global Status Bar component. ",
+    "description": "Background color of the Global Status Bar component",
     "property": "background",
     "category": "color",
     "component": "gsb",
@@ -332,7 +332,7 @@
   {
     "name": "gsb-color-text",
     "value": "#ffffff",
-    "description": "The primary text color used within the Global Status Bar.",
+    "description": "Primary text color used within the Global Status Bar",
     "property": "text",
     "category": "color",
     "component": "gsb",
@@ -342,7 +342,7 @@
   {
     "name": "slider-radius-background-track",
     "value": "1px",
-    "description": "The background track border radius",
+    "description": "Background track border radius",
     "property": "background-track",
     "category": "borderRadius",
     "component": "slider",
@@ -351,7 +351,7 @@
   {
     "name": "checkbox-radius",
     "value": "2px",
-    "description": "The checkbox border radius",
+    "description": "Checkbox border radius",
     "category": "borderRadius",
     "component": "checkbox",
     "tokenLevel": "component"
@@ -359,7 +359,7 @@
   {
     "name": "radio-radius-inner",
     "value": "4px",
-    "description": "The inside radio border radius",
+    "description": "Inside radio border radius",
     "property": "inner",
     "category": "borderRadius",
     "component": "radio",
@@ -368,7 +368,7 @@
   {
     "name": "radio-radius-outer",
     "value": "9px",
-    "description": "The outside radio border radius",
+    "description": "Outside radio border radius",
     "property": "outer",
     "category": "borderRadius",
     "component": "radio",
@@ -377,7 +377,7 @@
   {
     "name": "switch-radius-track",
     "value": "10px",
-    "description": "The switch track's border radius",
+    "description": "Switch track's border radius",
     "property": "track",
     "category": "borderRadius",
     "component": "switch",
@@ -406,7 +406,7 @@
   {
     "name": "scrollbar-radius",
     "value": "4px",
-    "description": "The scrollbar's border radius",
+    "description": "Scrollbar's border radius",
     "category": "borderRadius",
     "component": "scrollbar",
     "tokenLevel": "component"
@@ -414,7 +414,7 @@
   {
     "name": "progress-radius-inner",
     "value": "8px",
-    "description": "The inside border radius",
+    "description": "Inside border radius",
     "property": "inner",
     "category": "borderRadius",
     "component": "progress",
@@ -423,7 +423,7 @@
   {
     "name": "progress-radius-outer",
     "value": "10px",
-    "description": "The outside border radius",
+    "description": "Outside border radius",
     "property": "outer",
     "category": "borderRadius",
     "component": "progress",
@@ -462,7 +462,7 @@
   {
     "name": "indeterminate-progress-radius-inner",
     "value": "23px",
-    "description": "The inside border radius",
+    "description": "Inside border radius",
     "property": "inner",
     "category": "borderRadius",
     "component": "indeterminate-progress",
@@ -471,7 +471,7 @@
   {
     "name": "indeterminate-progress-radius-outer",
     "value": "30px",
-    "description": "The outside border radius",
+    "description": "Outside border radius",
     "property": "outer",
     "category": "borderRadius",
     "component": "indeterminate-progress",
@@ -480,7 +480,7 @@
   {
     "name": "notification-banner-radius-inner",
     "value": "2px",
-    "description": "The inner radius of Notification Banner outlines.",
+    "description": "Inner radius of Notification Banner outlines",
     "property": "inner",
     "category": "borderRadius",
     "component": "notification-banner",
@@ -489,7 +489,7 @@
   {
     "name": "notification-banner-radius-outer",
     "value": "3px",
-    "description": "The outer radius of Notification Banner outlines.",
+    "description": "Outer radius of Notification Banner outlines",
     "property": "outer",
     "category": "borderRadius",
     "component": "notification-banner",
@@ -499,7 +499,7 @@
   {
     "name": "notification-banner-color-border-inner-normal",
     "value": "#00e200",
-    "description": "The fill color of the Normal Notification Banner background.",
+    "description": "Fill color of the Normal Notification Banner background",
     "property": "border",
     "category": "color",
     "component": "notification-banner",
@@ -509,7 +509,7 @@
   {
     "name": "notification-banner-color-border-inner-caution",
     "value": "#fad800",
-    "description": "The fill color of the Caution Notification Banner background.",
+    "description": "Fill color of the Caution Notification Banner background",
     "property": "border",
     "category": "color",
     "component": "notification-banner",
@@ -519,7 +519,7 @@
   {
     "name": "notification-banner-color-border-inner-serious",
     "value": "#ffaf3d",
-    "description": "The fill color of the Serious Notification Banner background.",
+    "description": "Fill color of the Serious Notification Banner background",
     "property": "border",
     "category": "color",
     "component": "notification-banner",
@@ -529,7 +529,7 @@
   {
     "name": "notification-banner-color-border-inner-critical",
     "value": "#ff2a04",
-    "description": "The fill color of the Critical Notification Banner background.",
+    "description": "Fill color of the Critical Notification Banner background",
     "property": "border",
     "category": "color",
     "component": "notification-banner",
@@ -539,7 +539,7 @@
   {
     "name": "notification-banner-color-border-inner-standby",
     "value": "#64d9ff",
-    "description": "The fill color of the Standby Notification Banner background.",
+    "description": "Fill color of the Standby Notification Banner background",
     "property": "border",
     "category": "color",
     "component": "notification-banner",
@@ -549,7 +549,7 @@
   {
     "name": "notification-banner-color-border-inner-off",
     "value": "#7b8089",
-    "description": "The fill color of the Off Notification Banner background.",
+    "description": "Fill color of the Off Notification Banner background",
     "property": "border",
     "category": "color",
     "component": "notification-banner",
@@ -559,7 +559,7 @@
   {
     "name": "notification-banner-color-border-inner-default",
     "value": "#005a8f",
-    "description": "The fill color of the Default Notification Banner background.",
+    "description": "Fill color of the Default Notification Banner background",
     "property": "border",
     "category": "color",
     "component": "notification-banner",
@@ -569,7 +569,7 @@
   {
     "name": "notification-banner-color-border-outer-normal",
     "value": "#005a00",
-    "description": "The stroke color of the Normal Notification Banner.",
+    "description": "Stroke color of the Normal Notification Banner",
     "property": "border",
     "category": "color",
     "component": "notification-banner",
@@ -579,7 +579,7 @@
   {
     "name": "notification-banner-color-border-outer-caution",
     "value": "#645600",
-    "description": "The stroke color of the Caution Notification Banner.",
+    "description": "Stroke color of the Caution Notification Banner",
     "property": "border",
     "category": "color",
     "component": "notification-banner",
@@ -589,7 +589,7 @@
   {
     "name": "notification-banner-color-border-outer-serious",
     "value": "#664618",
-    "description": "The stroke color of the Serious Notification Banner.",
+    "description": "Stroke color of the Serious Notification Banner",
     "property": "border",
     "category": "color",
     "component": "notification-banner",
@@ -599,7 +599,7 @@
   {
     "name": "notification-banner-color-border-outer-critical",
     "value": "#661102",
-    "description": "The stroke color of the Critical Notification Banner.",
+    "description": "Stroke color of the Critical Notification Banner",
     "property": "border",
     "category": "color",
     "component": "notification-banner",
@@ -609,7 +609,7 @@
   {
     "name": "notification-banner-color-border-outer-standby",
     "value": "#285766",
-    "description": "The stroke color of the Standby Notification Banner.",
+    "description": "Stroke color of the Standby Notification Banner",
     "property": "border",
     "category": "color",
     "component": "notification-banner",
@@ -619,7 +619,7 @@
   {
     "name": "notification-banner-color-border-outer-off",
     "value": "#3c3e42",
-    "description": "The stroke color of the Off Notification Banner.",
+    "description": "Stroke color of the Off Notification Banner",
     "property": "border",
     "category": "color",
     "component": "notification-banner",
@@ -629,7 +629,7 @@
   {
     "name": "notification-banner-color-border-outer-default",
     "value": "#005a8f",
-    "description": "The stroke color of the Default Notification Banner.",
+    "description": "Stroke color of the Default Notification Banner",
     "property": "border",
     "category": "color",
     "component": "notification-banner",
@@ -639,7 +639,7 @@
   {
     "name": "menu-divider-color-fill",
     "value": "#51555b",
-    "description": "The fill color for menu dividers",
+    "description": "Fill color for menu dividers",
     "property": "divider",
     "category": "color",
     "component": "menu",
@@ -677,7 +677,7 @@
   {
     "name": "tooltip-color-background",
     "value": "#bbc1c9",
-    "description": "The background color for Tooltips",
+    "description": "Background color for Tooltips",
     "property": "background",
     "category": "color",
     "component": "tooltip",
@@ -687,7 +687,7 @@
   {
     "name": "tooltip-color-text",
     "value": "#000000",
-    "description": "The text color for Tooltips",
+    "description": "Text color for Tooltips",
     "property": "text",
     "category": "color",
     "component": "tooltip",
@@ -697,7 +697,7 @@
   {
     "name": "tooltip-radius",
     "value": "1px",
-    "description": "The tooltip border radius",
+    "description": "Tooltip border radius",
     "category": "borderRadius",
     "component": "tooltip",
     "tokenLevel": "component"
@@ -725,7 +725,7 @@
   {
     "name": "opacity-25",
     "value": "25%",
-    "description": "used in drop shadow for scrollbars in light theme ",
+    "description": "Opacity used in drop shadow for scrollbars in light theme",
     "property": "25",
     "category": "opacity",
     "component": null,
@@ -734,7 +734,7 @@
   {
     "name": "opacity-35",
     "value": "35%",
-    "description": "Used in drop shadow for dialogs in light theme",
+    "description": "Opacity used in drop shadow for dialogs in light theme",
     "property": "35",
     "category": "opacity",
     "component": null,
@@ -743,6 +743,7 @@
   {
     "name": "opacity-40",
     "value": "40%",
+    "description": "Opacity used in disabled states",
     "property": "40",
     "category": "opacity",
     "component": null,
@@ -751,7 +752,7 @@
   {
     "name": "opacity-45",
     "value": "45%",
-    "description": "Used in drop shadow for dialogs",
+    "description": "Opacity used in drop shadow for dialogs",
     "property": "45",
     "category": "opacity",
     "component": null,
@@ -768,7 +769,7 @@
   {
     "name": "opacity-disabled",
     "value": "40%",
-    "description": "Used to represent disabled state",
+    "description": "Opacity used in disabled state",
     "property": "disabled",
     "category": "opacity",
     "component": null,
@@ -1593,7 +1594,7 @@
   {
     "name": "color-background-base-default",
     "value": "#eaeef4",
-    "description": "The background color of base elements, like the app or popup menus.",
+    "description": "Background color of base elements, like the app or popup menus",
     "property": "background",
     "category": "color",
     "component": null,
@@ -1603,7 +1604,7 @@
   {
     "name": "color-background-base-header",
     "value": "#f5f6f9",
-    "description": "The background color for the header of base elements.",
+    "description": "Background color for the header of base elements",
     "property": "background",
     "category": "color",
     "component": null,
@@ -1613,7 +1614,7 @@
   {
     "name": "color-background-base-hover",
     "value": "#98bdd3",
-    "description": "The background color of base elements, like popup menus, when they are hovered over.",
+    "description": "Background color of base elements, like popup menus, when they are hovered over",
     "property": "background",
     "category": "color",
     "component": null,
@@ -1623,7 +1624,7 @@
   {
     "name": "color-background-base-selected",
     "value": "#cee9fc",
-    "description": "The background color of base elements, like popup menus, when they are selected.",
+    "description": "Background color of base elements, like popup menus, when they are selected",
     "property": "background",
     "category": "color",
     "component": null,
@@ -1633,7 +1634,7 @@
   {
     "name": "color-background-surface-default",
     "value": "#ffffff",
-    "description": "The background color of surface elements, like panels or dialogs.",
+    "description": "Background color of surface elements, like panels or dialogs",
     "property": "background",
     "category": "color",
     "component": null,
@@ -1643,7 +1644,7 @@
   {
     "name": "color-background-surface-header",
     "value": "#f5f6f9",
-    "description": "The background color for the header of surface elements, including dialogs and table headers.",
+    "description": "Background color for the header of surface elements, including dialogs and table headers",
     "property": "background",
     "category": "color",
     "component": null,
@@ -1653,7 +1654,7 @@
   {
     "name": "color-background-surface-hover",
     "value": "#daeeff",
-    "description": "The background color of surface elements, like cards or table rows, when they are hovered over.",
+    "description": "Background color of surface elements, like cards or table rows, when they are hovered over",
     "property": "background",
     "category": "color",
     "component": null,
@@ -1663,7 +1664,7 @@
   {
     "name": "color-background-surface-selected",
     "value": "#cee9fc",
-    "description": "The background color of surface elements, like cards or table rows, when they are selected.",
+    "description": "Background color of surface elements, like cards or table rows, when they are selected",
     "property": "background",
     "category": "color",
     "component": null,
@@ -1673,7 +1674,7 @@
   {
     "name": "color-background-interactive-default",
     "value": "#005a8f",
-    "description": "The primary color used for the backgrounds of interactive elements.",
+    "description": "Primary color used for the backgrounds of interactive elements",
     "property": "background",
     "category": "color",
     "component": null,
@@ -1683,7 +1684,7 @@
   {
     "name": "color-background-interactive-hover",
     "value": "#004872",
-    "description": "The hover color used for the backgrounds of interactive elements.",
+    "description": "Hover color used for the backgrounds of interactive elements",
     "property": "background",
     "category": "color",
     "component": null,
@@ -1693,7 +1694,7 @@
   {
     "name": "color-background-interactive-muted",
     "value": "#2f7aa7",
-    "description": "A muted version of the primary color used for the background of interactive elements that don't need to be as strong as the primary color.",
+    "description": "Muted version of the primary color used for the background of interactive elements that don't need to be as strong as the primary color",
     "property": "background",
     "category": "color",
     "component": null,
@@ -1703,7 +1704,7 @@
   {
     "name": "color-text-primary",
     "value": "#292a2d",
-    "description": "The primary color used for text within the application.",
+    "description": "Primary color used for text within the application",
     "property": "text",
     "category": "color",
     "component": null,
@@ -1713,7 +1714,7 @@
   {
     "name": "color-text-secondary",
     "value": "#51555b",
-    "description": "The color used for text when less emphasis is needed.",
+    "description": "Color used for text when less emphasis is needed",
     "property": "text",
     "category": "color",
     "component": null,
@@ -1723,7 +1724,7 @@
   {
     "name": "color-text-placeholder",
     "value": "#7b8089",
-    "description": "The text color used for placeholder text in input and form fields.",
+    "description": "Text color used for placeholder text in input and form fields",
     "property": "text",
     "category": "color",
     "component": null,
@@ -1733,7 +1734,7 @@
   {
     "name": "color-text-inverse",
     "value": "#ffffff",
-    "description": "The color used for text on reversed backgrounds.",
+    "description": "Color used for text on reversed backgrounds",
     "property": "text",
     "category": "color",
     "component": null,
@@ -1743,7 +1744,7 @@
   {
     "name": "color-text-interactive-default",
     "value": "#005a8f",
-    "description": "The primary color used for interactive text elements.",
+    "description": "Primary color used for interactive text elements",
     "property": "text",
     "category": "color",
     "component": null,
@@ -1753,7 +1754,7 @@
   {
     "name": "color-text-interactive-hover",
     "value": "#004872",
-    "description": "The hover color used for interactive text elements. ",
+    "description": "Hover color used for interactive text elements",
     "property": "text",
     "category": "color",
     "component": null,
@@ -1763,7 +1764,7 @@
   {
     "name": "color-text-white",
     "value": "#ffffff",
-    "description": "Text that is white across all themes. Used for classification and status banners that do not change color in various themes.",
+    "description": "Text that is white across all themes. Used for classification and status banners that do not change color in various themes",
     "property": "text",
     "category": "color",
     "component": null,
@@ -1773,7 +1774,7 @@
   {
     "name": "color-text-black",
     "value": "#000000",
-    "description": "Text that is black across all themes. Used for classification and status banners that do not change color in various themes.",
+    "description": "Text that is black across all themes. Used for classification and status banners that do not change color in various themes",
     "property": "text",
     "category": "color",
     "component": null,
@@ -1783,7 +1784,7 @@
   {
     "name": "color-text-error",
     "value": "#c8102e",
-    "description": "The text color used for form error messages.",
+    "description": "Text color used for form error messages",
     "property": "text",
     "category": "color",
     "component": null,
@@ -1793,7 +1794,7 @@
   {
     "name": "color-border-interactive-default",
     "value": "#005a8f",
-    "description": "The primary color used for the border of interactive elements.",
+    "description": "Primary color used for the border of interactive elements",
     "property": "border",
     "category": "color",
     "component": null,
@@ -1803,7 +1804,7 @@
   {
     "name": "color-border-interactive-hover",
     "value": "#004872",
-    "description": "The hover color used for the border of interactive elements.",
+    "description": "Hover color used for the border of interactive elements",
     "property": "border",
     "category": "color",
     "component": null,
@@ -1813,7 +1814,7 @@
   {
     "name": "color-border-interactive-muted",
     "value": "#2f7aa7",
-    "description": "A muted version of the primary color used for the border of interactive elements that don't need to be as strong as the primary color.",
+    "description": "Muted version of the primary color used for the border of interactive elements that don't need to be as strong as the primary color",
     "property": "border",
     "category": "color",
     "component": null,
@@ -1823,7 +1824,7 @@
   {
     "name": "color-border-error",
     "value": "#c8102e",
-    "description": "The border color used for form error borders.",
+    "description": "Border color used for form error borders",
     "property": "border",
     "category": "color",
     "component": null,
@@ -1833,7 +1834,7 @@
   {
     "name": "color-border-focus-default",
     "value": "#b534ce",
-    "description": "The color of a focused element's outline",
+    "description": "Color of a focused element's outline",
     "property": "border",
     "category": "color",
     "component": null,
@@ -1843,7 +1844,7 @@
   {
     "name": "color-status-critical",
     "value": "#ff2a04",
-    "description": "The fill color of the Critical status symbol on a light background.",
+    "description": "Fill color of the Critical status symbol on a light background",
     "property": "status",
     "category": "color",
     "component": null,
@@ -1853,7 +1854,7 @@
   {
     "name": "color-status-serious",
     "value": "#ffaf3d",
-    "description": "The fill color of the Serious status symbol on a light background.",
+    "description": "Fill color of the Serious status symbol on a light background",
     "property": "status",
     "category": "color",
     "component": null,
@@ -1863,7 +1864,7 @@
   {
     "name": "color-status-caution",
     "value": "#fad800",
-    "description": "The fill color of the Caution status symbol on a light background.",
+    "description": "Fill color of the Caution status symbol on a light background",
     "property": "status",
     "category": "color",
     "component": null,
@@ -1873,7 +1874,7 @@
   {
     "name": "color-status-normal",
     "value": "#00e200",
-    "description": "The fill color of the Normal status symbol on a light background.",
+    "description": "Fill color of the Normal status symbol on a light background",
     "property": "status",
     "category": "color",
     "component": null,
@@ -1883,7 +1884,7 @@
   {
     "name": "color-status-standby",
     "value": "#64d9ff",
-    "description": "The fill color of the Standby status symbol on a light background.",
+    "description": "Fill color of the Standby status symbol on a light background",
     "property": "status",
     "category": "color",
     "component": null,
@@ -1893,7 +1894,7 @@
   {
     "name": "color-status-off",
     "value": "#7b8089",
-    "description": "The fill color of the Off status symbol on a light background.",
+    "description": "Fill color of the Off status symbol on a light background",
     "property": "status",
     "category": "color",
     "component": null,
@@ -1903,7 +1904,7 @@
   {
     "name": "color-classification-topsecretsci",
     "value": "#fce83a",
-    "description": "The color used to indicate the Top Secret//SCI classification.",
+    "description": "Color used to indicate the Top Secret//SCI classification",
     "property": "classification",
     "category": "color",
     "component": null,
@@ -1913,7 +1914,7 @@
   {
     "name": "color-classification-topsecret",
     "value": "#ff8c00",
-    "description": "The color used to indicate the Top Secret classification.",
+    "description": "Color used to indicate the Top Secret classification",
     "property": "classification",
     "category": "color",
     "component": null,
@@ -1923,7 +1924,7 @@
   {
     "name": "color-classification-secret",
     "value": "#c8102e",
-    "description": "The color used to indicate the Secret classification.",
+    "description": "Color used to indicate the Secret classification",
     "property": "classification",
     "category": "color",
     "component": null,
@@ -1933,7 +1934,7 @@
   {
     "name": "color-classification-confidential",
     "value": "#0033a0",
-    "description": "The color used to indicate the Confidential classification.",
+    "description": "Color used to indicate the Confidential classification",
     "property": "classification",
     "category": "color",
     "component": null,
@@ -1943,7 +1944,7 @@
   {
     "name": "color-classification-cui",
     "value": "#502b85",
-    "description": "The color used to indicate the CUI classification.",
+    "description": "Color used to indicate the CUI classification",
     "property": "classification",
     "category": "color",
     "component": null,
@@ -1953,7 +1954,7 @@
   {
     "name": "color-classification-unclassified",
     "value": "#007a33",
-    "description": "The color used to indicate the Unclassified classification.",
+    "description": "Color used to indicate the Unclassified classification",
     "property": "classification",
     "category": "color",
     "component": null,
@@ -1990,7 +1991,7 @@
   {
     "name": "border-width-lg",
     "value": "4px",
-    "description": "large border width",
+    "description": "Large border width",
     "property": "lg",
     "category": "borderWidth",
     "component": null,
@@ -1999,7 +2000,7 @@
   {
     "name": "border-width-focus-default",
     "value": "1px",
-    "description": "The thickness of a focused element's outline",
+    "description": "Thickness of a focused element's outline",
     "property": "focus",
     "category": "borderWidth",
     "component": null,
@@ -2009,7 +2010,7 @@
   {
     "name": "radius-base",
     "value": "3px",
-    "description": "The default base border radius",
+    "description": "Default base border radius",
     "property": "base",
     "category": "borderRadius",
     "component": null,
@@ -2018,7 +2019,7 @@
   {
     "name": "radius-circle",
     "value": "50%",
-    "description": "A completely rounded border radius, used to create circles.",
+    "description": "Completely rounded border radius, used to create circles",
     "property": "circle",
     "category": "borderRadius",
     "component": null,
@@ -3548,7 +3549,7 @@
   {
     "name": "spacing-focus-default",
     "value": "0.125rem",
-    "description": "The amount of space between a focused element's outline and edge.",
+    "description": "Space between a focused element's outline and edge",
     "property": "focus",
     "category": "spacing",
     "component": null,

--- a/dist/json/docs.json
+++ b/dist/json/docs.json
@@ -2,7 +2,7 @@
   {
     "name": "link-color-text-default",
     "value": "#4dacff",
-    "description": "The color used for links in default state.",
+    "description": "Color used for links in default state",
     "property": "text",
     "category": "color",
     "component": "link",
@@ -12,7 +12,7 @@
   {
     "name": "link-color-text-hover",
     "value": "#4dacff",
-    "description": "The color used for links in hover state. Links do not change color on hover.",
+    "description": "Color used for links in hover state. Links do not change color on hover",
     "property": "text",
     "category": "color",
     "component": "link",
@@ -22,7 +22,7 @@
   {
     "name": "card-color-border",
     "value": "#51555b",
-    "description": "The border color used for the Card component.",
+    "description": "Border color used for the Card component",
     "property": "border",
     "category": "color",
     "component": "card",
@@ -32,7 +32,7 @@
   {
     "name": "container-color-border",
     "value": "#000000",
-    "description": "The border color used for the Container component.",
+    "description": "Border color used for the Container component",
     "property": "border",
     "category": "color",
     "component": "container",
@@ -42,7 +42,7 @@
   {
     "name": "classification-banner-color-background-topsecretsci",
     "value": "#fce83a",
-    "description": "The background color of the Top Secret//SCI classification banner.",
+    "description": "Background color of the Top Secret//SCI classification banner",
     "property": "background",
     "category": "color",
     "component": "classification-banner",
@@ -52,7 +52,7 @@
   {
     "name": "classification-banner-color-background-topsecret",
     "value": "#ff8c00",
-    "description": "The background color of the Top Secret classification banner.",
+    "description": "Background color of the Top Secret classification banner",
     "property": "background",
     "category": "color",
     "component": "classification-banner",
@@ -62,7 +62,7 @@
   {
     "name": "classification-banner-color-background-secret",
     "value": "#c8102e",
-    "description": "The background color of the Secret classification banner.",
+    "description": "Background color of the Secret classification banner",
     "property": "background",
     "category": "color",
     "component": "classification-banner",
@@ -72,7 +72,7 @@
   {
     "name": "classification-banner-color-background-confidential",
     "value": "#0033a0",
-    "description": "The background color of the Confidential classification banner.",
+    "description": "Background color of the Confidential classification banner",
     "property": "background",
     "category": "color",
     "component": "classification-banner",
@@ -82,7 +82,7 @@
   {
     "name": "classification-banner-color-background-cui",
     "value": "#502b85",
-    "description": "The background color of the CUI classification banner.",
+    "description": "Background color of the CUI classification banner",
     "property": "background",
     "category": "color",
     "component": "classification-banner",
@@ -92,7 +92,7 @@
   {
     "name": "classification-banner-color-background-unclassified",
     "value": "#007a33",
-    "description": "The background color of the Unclassified classification banner.",
+    "description": "Background color of the Unclassified classification banner",
     "property": "background",
     "category": "color",
     "component": "classification-banner",
@@ -102,7 +102,7 @@
   {
     "name": "status-symbol-color-fill-critical-on-dark",
     "value": "#ff3838",
-    "description": "The fill color of the Critical status symbol on a dark background.",
+    "description": "Fill color of the Critical status symbol on a dark background",
     "property": "fill",
     "category": "color",
     "component": "status-symbol",
@@ -112,7 +112,7 @@
   {
     "name": "status-symbol-color-fill-critical-on-light",
     "value": "#ff2a04",
-    "description": "The fill color of the Critical status symbol on a light background.",
+    "description": "Fill color of the Critical status symbol on a light background",
     "property": "fill",
     "category": "color",
     "component": "status-symbol",
@@ -122,7 +122,7 @@
   {
     "name": "status-symbol-color-fill-serious-on-dark",
     "value": "#ffb302",
-    "description": "The fill color of the Serious status symbol on a dark background.",
+    "description": "Fill color of the Serious status symbol on a dark background",
     "property": "fill",
     "category": "color",
     "component": "status-symbol",
@@ -132,7 +132,7 @@
   {
     "name": "status-symbol-color-fill-serious-on-light",
     "value": "#ffaf3d",
-    "description": "The fill color of the Serious status symbol on a light background.",
+    "description": "Fill color of the Serious status symbol on a light background",
     "property": "fill",
     "category": "color",
     "component": "status-symbol",
@@ -142,7 +142,7 @@
   {
     "name": "status-symbol-color-fill-caution-on-dark",
     "value": "#fce83a",
-    "description": "The fill color of the Caution status symbol on a dark background.",
+    "description": "Fill color of the Caution status symbol on a dark background",
     "property": "fill",
     "category": "color",
     "component": "status-symbol",
@@ -152,7 +152,7 @@
   {
     "name": "status-symbol-color-fill-caution-on-light",
     "value": "#fad800",
-    "description": "The fill color of the Caution status symbol on a light background.",
+    "description": "Fill color of the Caution status symbol on a light background",
     "property": "fill",
     "category": "color",
     "component": "status-symbol",
@@ -162,7 +162,7 @@
   {
     "name": "status-symbol-color-fill-normal-on-dark",
     "value": "#56f000",
-    "description": "The fill color of the Normal status symbol on a dark background.",
+    "description": "Fill color of the Normal status symbol on a dark background",
     "property": "fill",
     "category": "color",
     "component": "status-symbol",
@@ -172,7 +172,7 @@
   {
     "name": "status-symbol-color-fill-normal-on-light",
     "value": "#00e200",
-    "description": "The fill color of the Normal status symbol on a light background.",
+    "description": "Fill color of the Normal status symbol on a light background",
     "property": "fill",
     "category": "color",
     "component": "status-symbol",
@@ -182,7 +182,7 @@
   {
     "name": "status-symbol-color-fill-standby-on-dark",
     "value": "#2dccff",
-    "description": "The fill color of the Standby status symbol on a dark background.",
+    "description": "Fill color of the Standby status symbol on a dark background",
     "property": "fill",
     "category": "color",
     "component": "status-symbol",
@@ -192,7 +192,7 @@
   {
     "name": "status-symbol-color-fill-standby-on-light",
     "value": "#64d9ff",
-    "description": "The fill color of the Standby status symbol on a light background.",
+    "description": "Fill color of the Standby status symbol on a light background",
     "property": "fill",
     "category": "color",
     "component": "status-symbol",
@@ -202,7 +202,7 @@
   {
     "name": "status-symbol-color-fill-off-on-dark",
     "value": "#a4abb6",
-    "description": "The fill color of the Off status symbol on a dark background.",
+    "description": "Fill color of the Off status symbol on a dark background",
     "property": "fill",
     "category": "color",
     "component": "status-symbol",
@@ -212,7 +212,7 @@
   {
     "name": "status-symbol-color-fill-off-on-light",
     "value": "#7b8089",
-    "description": "The fill color of the Off status symbol on a light background.",
+    "description": "Fill color of the Off status symbol on a light background",
     "property": "fill",
     "category": "color",
     "component": "status-symbol",
@@ -222,7 +222,7 @@
   {
     "name": "status-symbol-color-border-critical",
     "value": "#661102",
-    "description": "The border color of the Critical status symbol on light backgrounds.",
+    "description": "Border color of the Critical status symbol on light backgrounds",
     "property": "border",
     "category": "color",
     "component": "status-symbol",
@@ -232,7 +232,7 @@
   {
     "name": "status-symbol-color-border-serious",
     "value": "#664618",
-    "description": "The border color of the Serious status symbol on light backgrounds.",
+    "description": "Border color of the Serious status symbol on light backgrounds",
     "property": "border",
     "category": "color",
     "component": "status-symbol",
@@ -242,7 +242,7 @@
   {
     "name": "status-symbol-color-border-caution",
     "value": "#645600",
-    "description": "The border color of the Caution status symbol on light backgrounds.",
+    "description": "Border color of the Caution status symbol on light backgrounds",
     "property": "border",
     "category": "color",
     "component": "status-symbol",
@@ -252,7 +252,7 @@
   {
     "name": "status-symbol-color-border-normal",
     "value": "#005a00",
-    "description": "The border color of the Normal status symbol on light backgrounds.",
+    "description": "Border color of the Normal status symbol on light backgrounds",
     "property": "border",
     "category": "color",
     "component": "status-symbol",
@@ -262,7 +262,7 @@
   {
     "name": "status-symbol-color-border-standby",
     "value": "#285766",
-    "description": "The border color of the Standby status symbol on light backgrounds.",
+    "description": "Border color of the Standby status symbol on light backgrounds",
     "property": "border",
     "category": "color",
     "component": "status-symbol",
@@ -272,7 +272,7 @@
   {
     "name": "status-symbol-color-border-off",
     "value": "#3c3e42",
-    "description": "The border color of the Off status symbol on light backgrounds.",
+    "description": "Border color of the Off status symbol on light backgrounds",
     "property": "border",
     "category": "color",
     "component": "status-symbol",
@@ -282,7 +282,7 @@
   {
     "name": "status-symbol-border-width-on-dark",
     "value": 0,
-    "description": "The border width for status symbols on a dark background",
+    "description": "Border width for status symbols on a dark background",
     "property": "on-dark",
     "category": "borderWidth",
     "component": "status-symbol",
@@ -292,7 +292,7 @@
   {
     "name": "status-symbol-border-width-on-light",
     "value": "1px",
-    "description": "The border width for status symbols on a light background",
+    "description": "Border width for status symbols on a light background",
     "property": "on-light",
     "category": "borderWidth",
     "component": "status-symbol",
@@ -302,7 +302,7 @@
   {
     "name": "gsb-icon-color-fill-default",
     "value": "#4dacff",
-    "description": "The primary color used for interactive elements in the Global Status Bar.",
+    "description": "Primary color used for interactive elements in the Global Status Bar",
     "property": "icon",
     "category": "color",
     "component": "gsb",
@@ -312,7 +312,7 @@
   {
     "name": "gsb-icon-color-fill-hover",
     "value": "#92cbff",
-    "description": "The hover color used for interactive elements in the Global Status Bar.",
+    "description": "Hover color used for interactive elements in the Global Status Bar",
     "property": "icon",
     "category": "color",
     "component": "gsb",
@@ -322,7 +322,7 @@
   {
     "name": "gsb-color-background",
     "value": "#172635",
-    "description": "The background color of the Global Status Bar component. ",
+    "description": "Background color of the Global Status Bar component",
     "property": "background",
     "category": "color",
     "component": "gsb",
@@ -332,7 +332,7 @@
   {
     "name": "gsb-color-text",
     "value": "#ffffff",
-    "description": "The primary text color used within the Global Status Bar.",
+    "description": "Primary text color used within the Global Status Bar",
     "property": "text",
     "category": "color",
     "component": "gsb",
@@ -342,7 +342,7 @@
   {
     "name": "slider-radius-background-track",
     "value": "1px",
-    "description": "The background track border radius",
+    "description": "Background track border radius",
     "property": "background-track",
     "category": "borderRadius",
     "component": "slider",
@@ -351,7 +351,7 @@
   {
     "name": "checkbox-radius",
     "value": "2px",
-    "description": "The checkbox border radius",
+    "description": "Checkbox border radius",
     "category": "borderRadius",
     "component": "checkbox",
     "tokenLevel": "component"
@@ -359,7 +359,7 @@
   {
     "name": "radio-radius-inner",
     "value": "4px",
-    "description": "The inside radio border radius",
+    "description": "Inside radio border radius",
     "property": "inner",
     "category": "borderRadius",
     "component": "radio",
@@ -368,7 +368,7 @@
   {
     "name": "radio-radius-outer",
     "value": "9px",
-    "description": "The outside radio border radius",
+    "description": "Outside radio border radius",
     "property": "outer",
     "category": "borderRadius",
     "component": "radio",
@@ -377,7 +377,7 @@
   {
     "name": "switch-radius-track",
     "value": "10px",
-    "description": "The switch track's border radius",
+    "description": "Switch track's border radius",
     "property": "track",
     "category": "borderRadius",
     "component": "switch",
@@ -406,7 +406,7 @@
   {
     "name": "scrollbar-radius",
     "value": "4px",
-    "description": "The scrollbar's border radius",
+    "description": "Scrollbar's border radius",
     "category": "borderRadius",
     "component": "scrollbar",
     "tokenLevel": "component"
@@ -414,7 +414,7 @@
   {
     "name": "progress-radius-inner",
     "value": "8px",
-    "description": "The inside border radius",
+    "description": "Inside border radius",
     "property": "inner",
     "category": "borderRadius",
     "component": "progress",
@@ -423,7 +423,7 @@
   {
     "name": "progress-radius-outer",
     "value": "10px",
-    "description": "The outside border radius",
+    "description": "Outside border radius",
     "property": "outer",
     "category": "borderRadius",
     "component": "progress",
@@ -462,7 +462,7 @@
   {
     "name": "indeterminate-progress-radius-inner",
     "value": "23px",
-    "description": "The inside border radius",
+    "description": "Inside border radius",
     "property": "inner",
     "category": "borderRadius",
     "component": "indeterminate-progress",
@@ -471,7 +471,7 @@
   {
     "name": "indeterminate-progress-radius-outer",
     "value": "30px",
-    "description": "The outside border radius",
+    "description": "Outside border radius",
     "property": "outer",
     "category": "borderRadius",
     "component": "indeterminate-progress",
@@ -480,7 +480,7 @@
   {
     "name": "notification-banner-radius-inner",
     "value": "2px",
-    "description": "The inner radius of Notification Banner outlines.",
+    "description": "Inner radius of Notification Banner outlines",
     "property": "inner",
     "category": "borderRadius",
     "component": "notification-banner",
@@ -489,7 +489,7 @@
   {
     "name": "notification-banner-radius-outer",
     "value": "3px",
-    "description": "The outer radius of Notification Banner outlines.",
+    "description": "Outer radius of Notification Banner outlines",
     "property": "outer",
     "category": "borderRadius",
     "component": "notification-banner",
@@ -499,7 +499,7 @@
   {
     "name": "notification-banner-color-border-inner-normal",
     "value": "#56f000",
-    "description": "The fill color of the Normal Notification Banner background.",
+    "description": "Fill color of the Normal Notification Banner background",
     "property": "border",
     "category": "color",
     "component": "notification-banner",
@@ -509,7 +509,7 @@
   {
     "name": "notification-banner-color-border-inner-caution",
     "value": "#fce83a",
-    "description": "The fill color of the Caution Notification Banner background.",
+    "description": "Fill color of the Caution Notification Banner background",
     "property": "border",
     "category": "color",
     "component": "notification-banner",
@@ -519,7 +519,7 @@
   {
     "name": "notification-banner-color-border-inner-serious",
     "value": "#ffb302",
-    "description": "The fill color of the Serious Notification Banner background.",
+    "description": "Fill color of the Serious Notification Banner background",
     "property": "border",
     "category": "color",
     "component": "notification-banner",
@@ -529,7 +529,7 @@
   {
     "name": "notification-banner-color-border-inner-critical",
     "value": "#ff3838",
-    "description": "The fill color of the Critical Notification Banner background.",
+    "description": "Fill color of the Critical Notification Banner background",
     "property": "border",
     "category": "color",
     "component": "notification-banner",
@@ -539,7 +539,7 @@
   {
     "name": "notification-banner-color-border-inner-standby",
     "value": "#2dccff",
-    "description": "The fill color of the Standby Notification Banner background.",
+    "description": "Fill color of the Standby Notification Banner background",
     "property": "border",
     "category": "color",
     "component": "notification-banner",
@@ -549,7 +549,7 @@
   {
     "name": "notification-banner-color-border-inner-off",
     "value": "#a4abb6",
-    "description": "The fill color of the Off Notification Banner background.",
+    "description": "Fill color of the Off Notification Banner background",
     "property": "border",
     "category": "color",
     "component": "notification-banner",
@@ -559,7 +559,7 @@
   {
     "name": "notification-banner-color-border-inner-default",
     "value": "#4dacff",
-    "description": "The fill color of the Default Notification Banner background.",
+    "description": "Fill color of the Default Notification Banner background",
     "property": "border",
     "category": "color",
     "component": "notification-banner",
@@ -569,7 +569,7 @@
   {
     "name": "notification-banner-color-border-outer-normal",
     "value": "#56f000",
-    "description": "The stroke color of the Normal Notification Banner.",
+    "description": "Stroke color of the Normal Notification Banner",
     "property": "border",
     "category": "color",
     "component": "notification-banner",
@@ -579,7 +579,7 @@
   {
     "name": "notification-banner-color-border-outer-caution",
     "value": "#fce83a",
-    "description": "The stroke color of the Caution Notification Banner.",
+    "description": "Stroke color of the Caution Notification Banner",
     "property": "border",
     "category": "color",
     "component": "notification-banner",
@@ -589,7 +589,7 @@
   {
     "name": "notification-banner-color-border-outer-serious",
     "value": "#ffb302",
-    "description": "The stroke color of the Serious Notification Banner.",
+    "description": "Stroke color of the Serious Notification Banner",
     "property": "border",
     "category": "color",
     "component": "notification-banner",
@@ -599,7 +599,7 @@
   {
     "name": "notification-banner-color-border-outer-critical",
     "value": "#ff3838",
-    "description": "The stroke color of the Critical Notification Banner.",
+    "description": "Stroke color of the Critical Notification Banner",
     "property": "border",
     "category": "color",
     "component": "notification-banner",
@@ -609,7 +609,7 @@
   {
     "name": "notification-banner-color-border-outer-standby",
     "value": "#2dccff",
-    "description": "The stroke color of the Standby Notification Banner.",
+    "description": "Stroke color of the Standby Notification Banner",
     "property": "border",
     "category": "color",
     "component": "notification-banner",
@@ -619,7 +619,7 @@
   {
     "name": "notification-banner-color-border-outer-off",
     "value": "#a4abb6",
-    "description": "The stroke color of the Off Notification Banner.",
+    "description": "Stroke color of the Off Notification Banner",
     "property": "border",
     "category": "color",
     "component": "notification-banner",
@@ -629,7 +629,7 @@
   {
     "name": "notification-banner-color-border-outer-default",
     "value": "#4dacff",
-    "description": "The stroke color of the Default Notification Banner.",
+    "description": "Stroke color of the Default Notification Banner",
     "property": "border",
     "category": "color",
     "component": "notification-banner",
@@ -639,7 +639,7 @@
   {
     "name": "menu-divider-color-fill",
     "value": "#51555b",
-    "description": "The fill color for menu dividers",
+    "description": "Fill color for menu dividers",
     "property": "divider",
     "category": "color",
     "component": "menu",
@@ -676,7 +676,7 @@
   {
     "name": "tooltip-color-background",
     "value": "#3c3e42",
-    "description": "The background color for Tooltips",
+    "description": "Background color for Tooltips",
     "property": "background",
     "category": "color",
     "component": "tooltip",
@@ -686,7 +686,7 @@
   {
     "name": "tooltip-color-text",
     "value": "#ffffff",
-    "description": "The text color for Tooltips",
+    "description": "Text color for Tooltips",
     "property": "text",
     "category": "color",
     "component": "tooltip",
@@ -696,7 +696,7 @@
   {
     "name": "tooltip-radius",
     "value": "1px",
-    "description": "The tooltip border radius",
+    "description": "Tooltip border radius",
     "category": "borderRadius",
     "component": "tooltip",
     "tokenLevel": "component"
@@ -722,7 +722,7 @@
   {
     "name": "opacity-25",
     "value": "25%",
-    "description": "used in drop shadow for scrollbars in light theme ",
+    "description": "Opacity used in drop shadow for scrollbars in light theme",
     "property": "25",
     "category": "opacity",
     "component": null,
@@ -731,7 +731,7 @@
   {
     "name": "opacity-35",
     "value": "35%",
-    "description": "Used in drop shadow for dialogs in light theme",
+    "description": "Opacity used in drop shadow for dialogs in light theme",
     "property": "35",
     "category": "opacity",
     "component": null,
@@ -740,6 +740,7 @@
   {
     "name": "opacity-40",
     "value": "40%",
+    "description": "Opacity used in disabled states",
     "property": "40",
     "category": "opacity",
     "component": null,
@@ -748,7 +749,7 @@
   {
     "name": "opacity-45",
     "value": "45%",
-    "description": "Used in drop shadow for dialogs",
+    "description": "Opacity used in drop shadow for dialogs",
     "property": "45",
     "category": "opacity",
     "component": null,
@@ -765,7 +766,7 @@
   {
     "name": "opacity-disabled",
     "value": "40%",
-    "description": "Used to represent disabled state",
+    "description": "Opacity used in disabled state",
     "property": "disabled",
     "category": "opacity",
     "component": null,
@@ -1590,7 +1591,7 @@
   {
     "name": "color-background-base-default",
     "value": "#101923",
-    "description": "The background color of base elements, like the app or popup menus.",
+    "description": "Background color of base elements, like the app or popup menus",
     "property": "background",
     "category": "color",
     "component": null,
@@ -1600,7 +1601,7 @@
   {
     "name": "color-background-base-header",
     "value": "#172635",
-    "description": "The background color for the header of base elements.",
+    "description": "Background color for the header of base elements",
     "property": "background",
     "category": "color",
     "component": null,
@@ -1610,7 +1611,7 @@
   {
     "name": "color-background-base-hover",
     "value": "#142435",
-    "description": "The background color of base elements, like popup menus, when they are hovered over.",
+    "description": "Background color of base elements, like popup menus, when they are hovered over",
     "property": "background",
     "category": "color",
     "component": null,
@@ -1620,7 +1621,7 @@
   {
     "name": "color-background-base-selected",
     "value": "#1c3f5e",
-    "description": "The background color of base elements, like popup menus, when they are selected.",
+    "description": "Background color of base elements, like popup menus, when they are selected",
     "property": "background",
     "category": "color",
     "component": null,
@@ -1630,7 +1631,7 @@
   {
     "name": "color-background-surface-default",
     "value": "#1b2d3e",
-    "description": "The background color of surface elements, like panels or dialogs.",
+    "description": "Background color of surface elements, like panels or dialogs",
     "property": "background",
     "category": "color",
     "component": null,
@@ -1640,7 +1641,7 @@
   {
     "name": "color-background-surface-header",
     "value": "#172635",
-    "description": "The background color for the header of surface elements, including dialogs and table headers.",
+    "description": "Background color for the header of surface elements, including dialogs and table headers",
     "property": "background",
     "category": "color",
     "component": null,
@@ -1650,7 +1651,7 @@
   {
     "name": "color-background-surface-hover",
     "value": "#1c3851",
-    "description": "The background color of surface elements, like cards or table rows, when they are hovered over.",
+    "description": "Background color of surface elements, like cards or table rows, when they are hovered over",
     "property": "background",
     "category": "color",
     "component": null,
@@ -1660,7 +1661,7 @@
   {
     "name": "color-background-surface-selected",
     "value": "#1c3f5e",
-    "description": "The background color of surface elements, like cards or table rows, when they are selected.",
+    "description": "Background color of surface elements, like cards or table rows, when they are selected",
     "property": "background",
     "category": "color",
     "component": null,
@@ -1670,7 +1671,7 @@
   {
     "name": "color-background-interactive-default",
     "value": "#4dacff",
-    "description": "The primary color used for the backgrounds of interactive elements.",
+    "description": "Primary color used for the backgrounds of interactive elements",
     "property": "background",
     "category": "color",
     "component": null,
@@ -1680,7 +1681,7 @@
   {
     "name": "color-background-interactive-hover",
     "value": "#92cbff",
-    "description": "The hover color used for the backgrounds of interactive elements.",
+    "description": "Hover color used for the backgrounds of interactive elements",
     "property": "background",
     "category": "color",
     "component": null,
@@ -1690,7 +1691,7 @@
   {
     "name": "color-background-interactive-muted",
     "value": "#2b659b",
-    "description": "A muted version of the primary color used for the background of interactive elements that don't need to be as strong as the primary color.",
+    "description": "Muted version of the primary color used for the background of interactive elements that don't need to be as strong as the primary color",
     "property": "background",
     "category": "color",
     "component": null,
@@ -1700,7 +1701,7 @@
   {
     "name": "color-text-primary",
     "value": "#ffffff",
-    "description": "The primary color used for text within the application.",
+    "description": "Primary color used for text within the application",
     "property": "text",
     "category": "color",
     "component": null,
@@ -1710,7 +1711,7 @@
   {
     "name": "color-text-secondary",
     "value": "#d4d8dd",
-    "description": "The color used for text when less emphasis is needed.",
+    "description": "Color used for text when less emphasis is needed",
     "property": "text",
     "category": "color",
     "component": null,
@@ -1720,7 +1721,7 @@
   {
     "name": "color-text-placeholder",
     "value": "#a4abb6",
-    "description": "The text color used for placeholder text in input and form fields.",
+    "description": "Text color used for placeholder text in input and form fields",
     "property": "text",
     "category": "color",
     "component": null,
@@ -1730,7 +1731,7 @@
   {
     "name": "color-text-inverse",
     "value": "#080c11",
-    "description": "The color used for text on reversed backgrounds.",
+    "description": "Color used for text on reversed backgrounds",
     "property": "text",
     "category": "color",
     "component": null,
@@ -1740,7 +1741,7 @@
   {
     "name": "color-text-interactive-default",
     "value": "#4dacff",
-    "description": "The primary color used for interactive text elements.",
+    "description": "Primary color used for interactive text elements",
     "property": "text",
     "category": "color",
     "component": null,
@@ -1750,7 +1751,7 @@
   {
     "name": "color-text-interactive-hover",
     "value": "#92cbff",
-    "description": "The hover color used for interactive text elements. ",
+    "description": "Hover color used for interactive text elements",
     "property": "text",
     "category": "color",
     "component": null,
@@ -1760,7 +1761,7 @@
   {
     "name": "color-text-white",
     "value": "#ffffff",
-    "description": "Text that is white across all themes. Used for classification and status banners that do not change color in various themes.",
+    "description": "Text that is white across all themes. Used for classification and status banners that do not change color in various themes",
     "property": "text",
     "category": "color",
     "component": null,
@@ -1770,7 +1771,7 @@
   {
     "name": "color-text-black",
     "value": "#000000",
-    "description": "Text that is black across all themes. Used for classification and status banners that do not change color in various themes.",
+    "description": "Text that is black across all themes. Used for classification and status banners that do not change color in various themes",
     "property": "text",
     "category": "color",
     "component": null,
@@ -1780,7 +1781,7 @@
   {
     "name": "color-text-error",
     "value": "#ff3838",
-    "description": "The text color used for form error messages.",
+    "description": "Text color used for form error messages",
     "property": "text",
     "category": "color",
     "component": null,
@@ -1790,7 +1791,7 @@
   {
     "name": "color-border-interactive-default",
     "value": "#4dacff",
-    "description": "The primary color used for the border of interactive elements.",
+    "description": "Primary color used for the border of interactive elements",
     "property": "border",
     "category": "color",
     "component": null,
@@ -1800,7 +1801,7 @@
   {
     "name": "color-border-interactive-hover",
     "value": "#92cbff",
-    "description": "The hover color used for the border of interactive elements.",
+    "description": "Hover color used for the border of interactive elements",
     "property": "border",
     "category": "color",
     "component": null,
@@ -1810,7 +1811,7 @@
   {
     "name": "color-border-interactive-muted",
     "value": "#2b659b",
-    "description": "A muted version of the primary color used for the border of interactive elements that don't need to be as strong as the primary color.",
+    "description": "Muted version of the primary color used for the border of interactive elements that don't need to be as strong as the primary color",
     "property": "border",
     "category": "color",
     "component": null,
@@ -1820,7 +1821,7 @@
   {
     "name": "color-border-error",
     "value": "#ff3838",
-    "description": "The border color used for form error borders.",
+    "description": "Border color used for form error borders",
     "property": "border",
     "category": "color",
     "component": null,
@@ -1830,7 +1831,7 @@
   {
     "name": "color-border-focus-default",
     "value": "#da9ce7",
-    "description": "The color of a focused element's outline",
+    "description": "Color of a focused element's outline",
     "property": "border",
     "category": "color",
     "component": null,
@@ -1840,7 +1841,7 @@
   {
     "name": "color-status-critical",
     "value": "#ff3838",
-    "description": "The color used to indicate items with a Critical status. Critical, form error, alert, emergency, urgent.",
+    "description": "Color used to indicate items with a Critical status. Critical, form error, alert, emergency, urgent",
     "property": "status",
     "category": "color",
     "component": null,
@@ -1850,7 +1851,7 @@
   {
     "name": "color-status-serious",
     "value": "#ffb302",
-    "description": "The color used to indicate items with a Serious status. Serious, warning, error, needs attention.",
+    "description": "Color used to indicate items with a Serious status. Serious, warning, error, needs attention",
     "property": "status",
     "category": "color",
     "component": null,
@@ -1860,7 +1861,7 @@
   {
     "name": "color-status-caution",
     "value": "#fce83a",
-    "description": "The color used to indicate items with a Caution status. Caution, unstable, unsatisfactory.",
+    "description": "Color used to indicate items with a Caution status. Caution, unstable, unsatisfactory",
     "property": "status",
     "category": "color",
     "component": null,
@@ -1870,7 +1871,7 @@
   {
     "name": "color-status-normal",
     "value": "#56f000",
-    "description": "The color used to indicate items with a Normal status. Normal, on, ok, fine, go, satisfactory, success.",
+    "description": "Color used to indicate items with a Normal status. Normal, on, ok, fine, go, satisfactory, success",
     "property": "status",
     "category": "color",
     "component": null,
@@ -1880,7 +1881,7 @@
   {
     "name": "color-status-standby",
     "value": "#2dccff",
-    "description": "The color used to indicate items with a Standby status. Standby, available, enabled.",
+    "description": "Color used to indicate items with a Standby status. Standby, available, enabled",
     "property": "status",
     "category": "color",
     "component": null,
@@ -1890,7 +1891,7 @@
   {
     "name": "color-status-off",
     "value": "#a4abb6",
-    "description": "The color used to indicate items with an Off status. Off, unavailable, disabled.",
+    "description": "Color used to indicate items with an Off status. Off, unavailable, disabled",
     "property": "status",
     "category": "color",
     "component": null,
@@ -1900,7 +1901,7 @@
   {
     "name": "color-classification-topsecretsci",
     "value": "#fce83a",
-    "description": "The color used to indicate the Top Secret//SCI classification.",
+    "description": "Color used to indicate the Top Secret//SCI classification",
     "property": "classification",
     "category": "color",
     "component": null,
@@ -1910,7 +1911,7 @@
   {
     "name": "color-classification-topsecret",
     "value": "#ff8c00",
-    "description": "The color used to indicate the Top Secret classification.",
+    "description": "Color used to indicate the Top Secret classification",
     "property": "classification",
     "category": "color",
     "component": null,
@@ -1920,7 +1921,7 @@
   {
     "name": "color-classification-secret",
     "value": "#c8102e",
-    "description": "The color used to indicate the Secret classification.",
+    "description": "Color used to indicate the Secret classification",
     "property": "classification",
     "category": "color",
     "component": null,
@@ -1930,7 +1931,7 @@
   {
     "name": "color-classification-confidential",
     "value": "#0033a0",
-    "description": "The color used to indicate the Confidential classification.",
+    "description": "Color used to indicate the Confidential classification",
     "property": "classification",
     "category": "color",
     "component": null,
@@ -1940,7 +1941,7 @@
   {
     "name": "color-classification-cui",
     "value": "#502b85",
-    "description": "The color used to indicate the CUI classification.",
+    "description": "Color used to indicate the CUI classification",
     "property": "classification",
     "category": "color",
     "component": null,
@@ -1950,7 +1951,7 @@
   {
     "name": "color-classification-unclassified",
     "value": "#007a33",
-    "description": "The color used to indicate the Unclassified classification.",
+    "description": "Color used to indicate the Unclassified classification",
     "property": "classification",
     "category": "color",
     "component": null,
@@ -1987,7 +1988,7 @@
   {
     "name": "border-width-lg",
     "value": "4px",
-    "description": "large border width",
+    "description": "Large border width",
     "property": "lg",
     "category": "borderWidth",
     "component": null,
@@ -1996,7 +1997,7 @@
   {
     "name": "border-width-focus-default",
     "value": "1px",
-    "description": "The thickness of a focused element's outline",
+    "description": "Thickness of a focused element's outline",
     "property": "focus",
     "category": "borderWidth",
     "component": null,
@@ -2006,7 +2007,7 @@
   {
     "name": "radius-base",
     "value": "3px",
-    "description": "The default base border radius",
+    "description": "Default base border radius",
     "property": "base",
     "category": "borderRadius",
     "component": null,
@@ -2015,7 +2016,7 @@
   {
     "name": "radius-circle",
     "value": "50%",
-    "description": "A completely rounded border radius, used to create circles.",
+    "description": "Completely rounded border radius, used to create circles",
     "property": "circle",
     "category": "borderRadius",
     "component": null,
@@ -3545,7 +3546,7 @@
   {
     "name": "spacing-focus-default",
     "value": "0.125rem",
-    "description": "The amount of space between a focused element's outline and edge.",
+    "description": "Space between a focused element's outline and edge",
     "property": "focus",
     "category": "spacing",
     "component": null,

--- a/dist/json/docs.json
+++ b/dist/json/docs.json
@@ -766,7 +766,7 @@
   {
     "name": "opacity-disabled",
     "value": "40%",
-    "description": "Opacity used in disabled state",
+    "description": "Opacity used to indicate the disabled state",
     "property": "disabled",
     "category": "opacity",
     "component": null,

--- a/tokens/base.component.json
+++ b/tokens/base.component.json
@@ -5,13 +5,13 @@
         "default": {
           "value": "#4dacff",
           "type": "color",
-          "description": "The color used for links in default state.",
+          "description": "Color used for links in default state",
           "rawValue": "{color.text.interactive.default}"
         },
         "hover": {
           "value": "#4dacff",
           "type": "color",
-          "description": "The color used for links in hover state. Links do not change color on hover.",
+          "description": "Color used for links in hover state. Links do not change color on hover",
           "rawValue": "{link.color.text.default}"
         }
       }
@@ -22,7 +22,7 @@
       "border": {
         "value": "#51555b",
         "type": "color",
-        "description": "The border color used for the Card component.",
+        "description": "Border color used for the Card component",
         "rawValue": "{color.palette.grey.700}"
       }
     }
@@ -32,7 +32,7 @@
       "border": {
         "value": "#000000",
         "type": "color",
-        "description": "The border color used for the Container component.",
+        "description": "Border color used for the Container component",
         "rawValue": "{color.palette.neutral.1000}"
       }
     }
@@ -43,37 +43,37 @@
         "topsecretsci": {
           "value": "#fce83a",
           "type": "color",
-          "description": "The background color of the Top Secret//SCI classification banner.",
+          "description": "Background color of the Top Secret//SCI classification banner",
           "rawValue": "{color.classification.topsecretsci}"
         },
         "topsecret": {
           "value": "#ff8c00",
           "type": "color",
-          "description": "The background color of the Top Secret classification banner.",
+          "description": "Background color of the Top Secret classification banner",
           "rawValue": "{color.classification.topsecret}"
         },
         "secret": {
           "value": "#c8102e",
           "type": "color",
-          "description": "The background color of the Secret classification banner.",
+          "description": "Background color of the Secret classification banner",
           "rawValue": "{color.classification.secret}"
         },
         "confidential": {
           "value": "#0033a0",
           "type": "color",
-          "description": "The background color of the Confidential classification banner.",
+          "description": "Background color of the Confidential classification banner",
           "rawValue": "{color.classification.confidential}"
         },
         "cui": {
           "value": "#502b85",
           "type": "color",
-          "description": "The background color of the CUI classification banner.",
+          "description": "Background color of the CUI classification banner",
           "rawValue": "{color.classification.cui}"
         },
         "unclassified": {
           "value": "#007a33",
           "type": "color",
-          "description": "The background color of the Unclassified classification banner.",
+          "description": "Background color of the Unclassified classification banner",
           "rawValue": "{color.classification.unclassified}"
         }
       }
@@ -86,13 +86,13 @@
           "on-dark": {
             "value": "#ff3838",
             "type": "color",
-            "description": "The fill color of the Critical status symbol on a dark background.",
+            "description": "Fill color of the Critical status symbol on a dark background",
             "rawValue": "{color.palette.red.500}"
           },
           "on-light": {
             "value": "#ff2a04",
             "type": "color",
-            "description": "The fill color of the Critical status symbol on a light background.",
+            "description": "Fill color of the Critical status symbol on a light background",
             "rawValue": "{color.palette.red.600}"
           }
         },
@@ -100,13 +100,13 @@
           "on-dark": {
             "value": "#ffb302",
             "type": "color",
-            "description": "The fill color of the Serious status symbol on a dark background.",
+            "description": "Fill color of the Serious status symbol on a dark background",
             "rawValue": "{color.palette.orange.500}"
           },
           "on-light": {
             "value": "#ffaf3d",
             "type": "color",
-            "description": "The fill color of the Serious status symbol on a light background.",
+            "description": "Fill color of the Serious status symbol on a light background",
             "rawValue": "{color.palette.orange.600}"
           }
         },
@@ -114,13 +114,13 @@
           "on-dark": {
             "value": "#fce83a",
             "type": "color",
-            "description": "The fill color of the Caution status symbol on a dark background.",
+            "description": "Fill color of the Caution status symbol on a dark background",
             "rawValue": "{color.palette.yellow.500}"
           },
           "on-light": {
             "value": "#fad800",
             "type": "color",
-            "description": "The fill color of the Caution status symbol on a light background.",
+            "description": "Fill color of the Caution status symbol on a light background",
             "rawValue": "{color.palette.yellow.600}"
           }
         },
@@ -128,13 +128,13 @@
           "on-dark": {
             "value": "#56f000",
             "type": "color",
-            "description": "The fill color of the Normal status symbol on a dark background.",
+            "description": "Fill color of the Normal status symbol on a dark background",
             "rawValue": "{color.palette.green.500}"
           },
           "on-light": {
             "value": "#00e200",
             "type": "color",
-            "description": "The fill color of the Normal status symbol on a light background.",
+            "description": "Fill color of the Normal status symbol on a light background",
             "rawValue": "{color.palette.green.600}"
           }
         },
@@ -142,13 +142,13 @@
           "on-dark": {
             "value": "#2dccff",
             "type": "color",
-            "description": "The fill color of the Standby status symbol on a dark background.",
+            "description": "Fill color of the Standby status symbol on a dark background",
             "rawValue": "{color.palette.cyan.600}"
           },
           "on-light": {
             "value": "#64d9ff",
             "type": "color",
-            "description": "The fill color of the Standby status symbol on a light background.",
+            "description": "Fill color of the Standby status symbol on a light background",
             "rawValue": "{color.palette.cyan.500}"
           }
         },
@@ -156,13 +156,13 @@
           "on-dark": {
             "value": "#a4abb6",
             "type": "color",
-            "description": "The fill color of the Off status symbol on a dark background.",
+            "description": "Fill color of the Off status symbol on a dark background",
             "rawValue": "{color.palette.grey.500}"
           },
           "on-light": {
             "value": "#7b8089",
             "type": "color",
-            "description": "The fill color of the Off status symbol on a light background.",
+            "description": "Fill color of the Off status symbol on a light background",
             "rawValue": "{color.palette.grey.600}"
           }
         }
@@ -171,37 +171,37 @@
         "critical": {
           "value": "#661102",
           "type": "color",
-          "description": "The border color of the Critical status symbol on light backgrounds.",
+          "description": "Border color of the Critical status symbol on light backgrounds",
           "rawValue": "{color.palette.red.900}"
         },
         "serious": {
           "value": "#664618",
           "type": "color",
-          "description": "The border color of the Serious status symbol on light backgrounds.",
+          "description": "Border color of the Serious status symbol on light backgrounds",
           "rawValue": "{color.palette.orange.900}"
         },
         "caution": {
           "value": "#645600",
           "type": "color",
-          "description": "The border color of the Caution status symbol on light backgrounds.",
+          "description": "Border color of the Caution status symbol on light backgrounds",
           "rawValue": "{color.palette.yellow.900}"
         },
         "normal": {
           "value": "#005a00",
           "type": "color",
-          "description": "The border color of the Normal status symbol on light backgrounds.",
+          "description": "Border color of the Normal status symbol on light backgrounds",
           "rawValue": "{color.palette.green.900}"
         },
         "standby": {
           "value": "#285766",
           "type": "color",
-          "description": "The border color of the Standby status symbol on light backgrounds.",
+          "description": "Border color of the Standby status symbol on light backgrounds",
           "rawValue": "{color.palette.cyan.900}"
         },
         "off": {
           "value": "#3c3e42",
           "type": "color",
-          "description": "The border color of the Off status symbol on light backgrounds.",
+          "description": "Border color of the Off status symbol on light backgrounds",
           "rawValue": "{color.palette.grey.800}"
         }
       }
@@ -210,13 +210,13 @@
       "on-dark": {
         "value": 0,
         "type": "borderWidth",
-        "description": "The border width for status symbols on a dark background",
+        "description": "Border width for status symbols on a dark background",
         "rawValue": "{borderWidth.none}"
       },
       "on-light": {
         "value": "1px",
         "type": "borderWidth",
-        "description": "The border width for status symbols on a light background",
+        "description": "Border width for status symbols on a light background",
         "rawValue": "{borderWidth.xs}"
       }
     }
@@ -228,13 +228,13 @@
           "default": {
             "value": "#4dacff",
             "type": "color",
-            "description": "The primary color used for interactive elements in the Global Status Bar.",
+            "description": "Primary color used for interactive elements in the Global Status Bar",
             "rawValue": "{color.palette.brightblue.500}"
           },
           "hover": {
             "value": "#92cbff",
             "type": "color",
-            "description": "The hover color used for interactive elements in the Global Status Bar.",
+            "description": "Hover color used for interactive elements in the Global Status Bar",
             "rawValue": "{color.palette.brightblue.400}"
           }
         }
@@ -244,13 +244,13 @@
       "background": {
         "value": "#172635",
         "type": "color",
-        "description": "The background color of the Global Status Bar component. ",
+        "description": "Background color of the Global Status Bar component",
         "rawValue": "{color.palette.darkblue.900}"
       },
       "text": {
         "value": "#ffffff",
         "type": "color",
-        "description": "The primary text color used within the Global Status Bar.",
+        "description": "Primary text color used within the Global Status Bar",
         "rawValue": "{color.palette.neutral.000}"
       }
     }
@@ -260,7 +260,7 @@
       "background-track": {
         "value": "1px",
         "type": "borderRadius",
-        "description": "The background track border radius",
+        "description": "Background track border radius",
         "rawValue": "1px"
       }
     }
@@ -269,7 +269,7 @@
     "radius": {
       "value": "2px",
       "type": "borderRadius",
-      "description": "The checkbox border radius",
+      "description": "Checkbox border radius",
       "rawValue": "2px"
     }
   },
@@ -278,13 +278,13 @@
       "inner": {
         "value": "4px",
         "type": "borderRadius",
-        "description": "The inside radio border radius",
+        "description": "Inside radio border radius",
         "rawValue": "4px"
       },
       "outer": {
         "value": "9px",
         "type": "borderRadius",
-        "description": "The outside radio border radius",
+        "description": "Outside radio border radius",
         "rawValue": "9px"
       }
     }
@@ -294,7 +294,7 @@
       "track": {
         "value": "10px",
         "type": "borderRadius",
-        "description": "The switch track's border radius",
+        "description": "Switch track's border radius",
         "rawValue": "10px"
       }
     }
@@ -347,7 +347,7 @@
     "radius": {
       "value": "4px",
       "type": "borderRadius",
-      "description": "The scrollbar's border radius",
+      "description": "Scrollbar's border radius",
       "rawValue": "4px"
     }
   },
@@ -356,13 +356,13 @@
       "inner": {
         "value": "8px",
         "type": "borderRadius",
-        "description": "The inside border radius",
+        "description": "Inside border radius",
         "rawValue": "8px"
       },
       "outer": {
         "value": "10px",
         "type": "borderRadius",
-        "description": "The outside border radius",
+        "description": "Outside border radius",
         "rawValue": "10px"
       }
     }
@@ -438,13 +438,13 @@
       "inner": {
         "value": "23px",
         "type": "borderRadius",
-        "description": "The inside border radius",
+        "description": "Inside border radius",
         "rawValue": "23px"
       },
       "outer": {
         "value": "30px",
         "type": "borderRadius",
-        "description": "The outside border radius",
+        "description": "Outside border radius",
         "rawValue": "30px"
       }
     }
@@ -454,13 +454,13 @@
       "inner": {
         "value": "2px",
         "type": "borderRadius",
-        "description": "The inner radius of Notification Banner outlines.",
+        "description": "Inner radius of Notification Banner outlines",
         "rawValue": "2px"
       },
       "outer": {
         "value": "3px",
         "type": "borderRadius",
-        "description": "The outer radius of Notification Banner outlines.",
+        "description": "Outer radius of Notification Banner outlines",
         "rawValue": "{radius.base}"
       }
     },
@@ -470,43 +470,43 @@
           "normal": {
             "value": "#56f000",
             "type": "color",
-            "description": "The fill color of the Normal Notification Banner background.",
+            "description": "Fill color of the Normal Notification Banner background",
             "rawValue": "{color.status.normal}"
           },
           "caution": {
             "value": "#fce83a",
             "type": "color",
-            "description": "The fill color of the Caution Notification Banner background.",
+            "description": "Fill color of the Caution Notification Banner background",
             "rawValue": "{color.status.caution}"
           },
           "serious": {
             "value": "#ffb302",
             "type": "color",
-            "description": "The fill color of the Serious Notification Banner background.",
+            "description": "Fill color of the Serious Notification Banner background",
             "rawValue": "{color.status.serious}"
           },
           "critical": {
             "value": "#ff3838",
             "type": "color",
-            "description": "The fill color of the Critical Notification Banner background.",
+            "description": "Fill color of the Critical Notification Banner background",
             "rawValue": "{color.status.critical}"
           },
           "standby": {
             "value": "#2dccff",
             "type": "color",
-            "description": "The fill color of the Standby Notification Banner background.",
+            "description": "Fill color of the Standby Notification Banner background",
             "rawValue": "{color.status.standby}"
           },
           "off": {
             "value": "#a4abb6",
             "type": "color",
-            "description": "The fill color of the Off Notification Banner background.",
+            "description": "Fill color of the Off Notification Banner background",
             "rawValue": "{color.status.off}"
           },
           "default": {
             "value": "#4dacff",
             "type": "color",
-            "description": "The fill color of the Default Notification Banner background.",
+            "description": "Fill color of the Default Notification Banner background",
             "rawValue": "{color.border.interactive.default}"
           }
         },
@@ -514,43 +514,43 @@
           "normal": {
             "value": "#56f000",
             "type": "color",
-            "description": "The stroke color of the Normal Notification Banner.",
+            "description": "Stroke color of the Normal Notification Banner",
             "rawValue": "{color.status.normal}"
           },
           "caution": {
             "value": "#fce83a",
             "type": "color",
-            "description": "The stroke color of the Caution Notification Banner.",
+            "description": "Stroke color of the Caution Notification Banner",
             "rawValue": "{color.status.caution}"
           },
           "serious": {
             "value": "#ffb302",
             "type": "color",
-            "description": "The stroke color of the Serious Notification Banner.",
+            "description": "Stroke color of the Serious Notification Banner",
             "rawValue": "{color.status.serious}"
           },
           "critical": {
             "value": "#ff3838",
             "type": "color",
-            "description": "The stroke color of the Critical Notification Banner.",
+            "description": "Stroke color of the Critical Notification Banner",
             "rawValue": "{color.status.critical}"
           },
           "standby": {
             "value": "#2dccff",
             "type": "color",
-            "description": "The stroke color of the Standby Notification Banner.",
+            "description": "Stroke color of the Standby Notification Banner",
             "rawValue": "{color.status.standby}"
           },
           "off": {
             "value": "#a4abb6",
             "type": "color",
-            "description": "The stroke color of the Off Notification Banner.",
+            "description": "Stroke color of the Off Notification Banner",
             "rawValue": "{color.status.off}"
           },
           "default": {
             "value": "#4dacff",
             "type": "color",
-            "description": "The stroke color of the Default Notification Banner.",
+            "description": "Stroke color of the Default Notification Banner",
             "rawValue": "{color.border.interactive.default}"
           }
         }
@@ -563,7 +563,7 @@
         "fill": {
           "value": "#51555b",
           "type": "color",
-          "description": "The fill color for menu dividers",
+          "description": "Fill color for menu dividers",
           "rawValue": "{color.palette.grey.700}"
         }
       }
@@ -605,20 +605,20 @@
       "background": {
         "value": "#3c3e42",
         "type": "color",
-        "description": "The background color for Tooltips",
+        "description": "Background color for Tooltips",
         "rawValue": "{color.palette.grey.800}"
       },
       "text": {
         "value": "#ffffff",
         "type": "color",
-        "description": "The text color for Tooltips",
+        "description": "Text color for Tooltips",
         "rawValue": "{color.text.white}"
       }
     },
     "radius": {
       "value": "1px",
       "type": "borderRadius",
-      "description": "The tooltip border radius",
+      "description": "Tooltip border radius",
       "rawValue": "1px"
     }
   },

--- a/tokens/base.reference.json
+++ b/tokens/base.reference.json
@@ -3,12 +3,12 @@
     "25": {
       "value": "25%",
       "type": "opacity",
-      "description": "used in drop shadow for scrollbars in light theme ",
+      "description": "Opacity used in drop shadow for scrollbars in light theme",
       "rawValue": "25%"
     },
     "35": {
       "value": "35%",
-      "description": "Used in drop shadow for dialogs in light theme",
+      "description": "Opacity used in drop shadow for dialogs in light theme",
       "type": "opacity",
       "rawValue": "35%"
     },
@@ -19,7 +19,7 @@
     },
     "45": {
       "value": "45%",
-      "description": "Used in drop shadow for dialogs",
+      "description": "Opacity used in drop shadow for dialogs",
       "type": "opacity",
       "rawValue": "45%"
     },
@@ -600,7 +600,7 @@
     "lg": {
       "value": "4px",
       "type": "borderWidth",
-      "description": "large border width",
+      "description": "Large border width",
       "rawValue": "4px"
     }
   },
@@ -608,13 +608,13 @@
     "base": {
       "value": "3px",
       "type": "borderRadius",
-      "description": "The default base border radius",
+      "description": "Default base border radius",
       "rawValue": "3px"
     },
     "circle": {
       "value": "50%",
       "type": "borderRadius",
-      "description": "A completely rounded border radius, used to create circles.",
+      "description": "Completely rounded border radius, used to create circles",
       "rawValue": "50%"
     }
   },

--- a/tokens/base.reference.json
+++ b/tokens/base.reference.json
@@ -15,6 +15,7 @@
     "40": {
       "value": "40%",
       "type": "opacity",
+      "description": "Opacity used in disabled states",
       "rawValue": "40%"
     },
     "45": {

--- a/tokens/base.system.json
+++ b/tokens/base.system.json
@@ -249,7 +249,7 @@
     "disabled": {
       "value": "40%",
       "type": "opacity",
-      "description": "Opacity used in disabled state",
+      "description": "Opacity used to indicate the disabled state",
       "rawValue": "{opacity.40}"
     }
   },

--- a/tokens/base.system.json
+++ b/tokens/base.system.json
@@ -5,25 +5,25 @@
         "default": {
           "value": "#101923",
           "type": "color",
-          "description": "The background color of base elements, like the app or popup menus.",
+          "description": "Background color of base elements, like the app or popup menus",
           "rawValue": "{color.palette.brightblue.900}"
         },
         "header": {
           "value": "#172635",
           "type": "color",
-          "description": "The background color for the header of base elements.",
+          "description": "Background color for the header of base elements",
           "rawValue": "{color.palette.darkblue.900}"
         },
         "hover": {
           "value": "#142435",
           "type": "color",
-          "description": "The background color of base elements, like popup menus, when they are hovered over.",
+          "description": "Background color of base elements, like popup menus, when they are hovered over",
           "rawValue": "{color.palette.brightblue.850}"
         },
         "selected": {
           "value": "#1c3f5e",
           "type": "color",
-          "description": "The background color of base elements, like popup menus, when they are selected.",
+          "description": "Background color of base elements, like popup menus, when they are selected",
           "rawValue": "{color.palette.darkblue.700}"
         }
       },
@@ -31,25 +31,25 @@
         "default": {
           "value": "#1b2d3e",
           "type": "color",
-          "description": "The background color of surface elements, like panels or dialogs.",
+          "description": "Background color of surface elements, like panels or dialogs",
           "rawValue": "{color.palette.darkblue.800}"
         },
         "header": {
           "value": "#172635",
           "type": "color",
-          "description": "The background color for the header of surface elements, including dialogs and table headers.",
+          "description": "Background color for the header of surface elements, including dialogs and table headers",
           "rawValue": "{color.palette.darkblue.900}"
         },
         "hover": {
           "value": "#1c3851",
           "type": "color",
-          "description": "The background color of surface elements, like cards or table rows, when they are hovered over.",
+          "description": "Background color of surface elements, like cards or table rows, when they are hovered over",
           "rawValue": "{color.palette.brightblue.800}"
         },
         "selected": {
           "value": "#1c3f5e",
           "type": "color",
-          "description": "The background color of surface elements, like cards or table rows, when they are selected.",
+          "description": "Background color of surface elements, like cards or table rows, when they are selected",
           "rawValue": "{color.palette.darkblue.700}"
         }
       },
@@ -57,19 +57,19 @@
         "default": {
           "value": "#4dacff",
           "type": "color",
-          "description": "The primary color used for the backgrounds of interactive elements.",
+          "description": "Primary color used for the backgrounds of interactive elements",
           "rawValue": "{color.palette.brightblue.500}"
         },
         "hover": {
           "value": "#92cbff",
           "type": "color",
-          "description": "The hover color used for the backgrounds of interactive elements.",
+          "description": "Hover color used for the backgrounds of interactive elements",
           "rawValue": "{color.palette.brightblue.400}"
         },
         "muted": {
           "value": "#2b659b",
           "type": "color",
-          "description": "A muted version of the primary color used for the background of interactive elements that don't need to be as strong as the primary color.",
+          "description": "Muted version of the primary color used for the background of interactive elements that don't need to be as strong as the primary color",
           "rawValue": "{color.palette.brightblue.700}"
         }
       }
@@ -78,57 +78,57 @@
       "primary": {
         "value": "#ffffff",
         "type": "color",
-        "description": "The primary color used for text within the application.",
+        "description": "Primary color used for text within the application",
         "rawValue": "{color.palette.neutral.000}"
       },
       "secondary": {
         "value": "#d4d8dd",
         "type": "color",
-        "description": "The color used for text when less emphasis is needed.",
+        "description": "Color used for text when less emphasis is needed",
         "rawValue": "{color.palette.grey.300}"
       },
       "placeholder": {
         "value": "#a4abb6",
         "type": "color",
-        "description": "The text color used for placeholder text in input and form fields.",
+        "description": "Text color used for placeholder text in input and form fields",
         "rawValue": "{color.palette.grey.500}"
       },
       "inverse": {
         "value": "#080c11",
         "type": "color",
-        "description": "The color used for text on reversed backgrounds.",
+        "description": "Color used for text on reversed backgrounds",
         "rawValue": "{color.palette.darkblue.950}"
       },
       "interactive": {
         "default": {
           "value": "#4dacff",
           "type": "color",
-          "description": "The primary color used for interactive text elements.",
+          "description": "Primary color used for interactive text elements",
           "rawValue": "{color.palette.brightblue.500}"
         },
         "hover": {
           "value": "#92cbff",
           "type": "color",
-          "description": "The hover color used for interactive text elements. ",
+          "description": "Hover color used for interactive text elements",
           "rawValue": "{color.palette.brightblue.400}"
         }
       },
       "white": {
         "value": "#ffffff",
         "type": "color",
-        "description": "Text that is white across all themes. Used for classification and status banners that do not change color in various themes.",
+        "description": "Text that is white across all themes. Used for classification and status banners that do not change color in various themes",
         "rawValue": "{color.palette.neutral.000}"
       },
       "black": {
         "value": "#000000",
         "type": "color",
-        "description": "Text that is black across all themes. Used for classification and status banners that do not change color in various themes.",
+        "description": "Text that is black across all themes. Used for classification and status banners that do not change color in various themes",
         "rawValue": "{color.palette.neutral.1000}"
       },
       "error": {
         "value": "#ff3838",
         "type": "color",
-        "description": "The text color used for form error messages.",
+        "description": "Text color used for form error messages",
         "rawValue": "{color.palette.red.500}"
       }
     },
@@ -137,33 +137,33 @@
         "default": {
           "value": "#4dacff",
           "type": "color",
-          "description": "The primary color used for the border of interactive elements.",
+          "description": "Primary color used for the border of interactive elements",
           "rawValue": "{color.palette.brightblue.500}"
         },
         "hover": {
           "value": "#92cbff",
           "type": "color",
-          "description": "The hover color used for the border of interactive elements.",
+          "description": "Hover color used for the border of interactive elements",
           "rawValue": "{color.palette.brightblue.400}"
         },
         "muted": {
           "value": "#2b659b",
           "type": "color",
-          "description": "A muted version of the primary color used for the border of interactive elements that don't need to be as strong as the primary color.",
+          "description": "Muted version of the primary color used for the border of interactive elements that don't need to be as strong as the primary color",
           "rawValue": "{color.palette.brightblue.700}"
         }
       },
       "error": {
         "value": "#ff3838",
         "type": "color",
-        "description": "The border color used for form error borders.",
+        "description": "Border color used for form error borders",
         "rawValue": "{color.palette.red.500}"
       },
       "focus": {
         "default": {
           "value": "#da9ce7",
           "type": "color",
-          "description": "The color of a focused element's outline",
+          "description": "Color of a focused element's outline",
           "rawValue": "{color.palette.pink.200}"
         }
       }
@@ -172,37 +172,37 @@
       "critical": {
         "value": "#ff3838",
         "type": "color",
-        "description": "The color used to indicate items with a Critical status. Critical, form error, alert, emergency, urgent.",
+        "description": "Color used to indicate items with a Critical status. Critical, form error, alert, emergency, urgent",
         "rawValue": "{color.palette.red.500}"
       },
       "serious": {
         "value": "#ffb302",
         "type": "color",
-        "description": "The color used to indicate items with a Serious status. Serious, warning, error, needs attention.",
+        "description": "Color used to indicate items with a Serious status. Serious, warning, error, needs attention",
         "rawValue": "{color.palette.orange.500}"
       },
       "caution": {
         "value": "#fce83a",
         "type": "color",
-        "description": "The color used to indicate items with a Caution status. Caution, unstable, unsatisfactory.",
+        "description": "Color used to indicate items with a Caution status. Caution, unstable, unsatisfactory",
         "rawValue": "{color.palette.yellow.500}"
       },
       "normal": {
         "value": "#56f000",
         "type": "color",
-        "description": "The color used to indicate items with a Normal status. Normal, on, ok, fine, go, satisfactory, success.",
+        "description": "Color used to indicate items with a Normal status. Normal, on, ok, fine, go, satisfactory, success",
         "rawValue": "{color.palette.green.500}"
       },
       "standby": {
         "value": "#2dccff",
         "type": "color",
-        "description": "The color used to indicate items with a Standby status. Standby, available, enabled.",
+        "description": "Color used to indicate items with a Standby status. Standby, available, enabled",
         "rawValue": "{color.palette.cyan.600}"
       },
       "off": {
         "value": "#a4abb6",
         "type": "color",
-        "description": "The color used to indicate items with an Off status. Off, unavailable, disabled.",
+        "description": "Color used to indicate items with an Off status. Off, unavailable, disabled",
         "rawValue": "{color.palette.grey.500}"
       }
     },
@@ -210,37 +210,37 @@
       "topsecretsci": {
         "value": "#fce83a",
         "type": "color",
-        "description": "The color used to indicate the Top Secret//SCI classification.",
+        "description": "Color used to indicate the Top Secret//SCI classification",
         "rawValue": "{color.palette.yellow.500}"
       },
       "topsecret": {
         "value": "#ff8c00",
         "type": "color",
-        "description": "The color used to indicate the Top Secret classification.",
+        "description": "Color used to indicate the Top Secret classification",
         "rawValue": "{color.palette.orange.700}"
       },
       "secret": {
         "value": "#c8102e",
         "type": "color",
-        "description": "The color used to indicate the Secret classification.",
+        "description": "Color used to indicate the Secret classification",
         "rawValue": "{color.palette.red.700}"
       },
       "confidential": {
         "value": "#0033a0",
         "type": "color",
-        "description": "The color used to indicate the Confidential classification.",
+        "description": "Color used to indicate the Confidential classification",
         "rawValue": "{color.palette.blue.800}"
       },
       "cui": {
         "value": "#502b85",
         "type": "color",
-        "description": "The color used to indicate the CUI classification.",
+        "description": "Color used to indicate the CUI classification",
         "rawValue": "{color.palette.violet.800}"
       },
       "unclassified": {
         "value": "#007a33",
         "type": "color",
-        "description": "The color used to indicate the Unclassified classification.",
+        "description": "Color used to indicate the Unclassified classification",
         "rawValue": "{color.palette.green.800}"
       }
     }
@@ -249,7 +249,7 @@
     "disabled": {
       "value": "40%",
       "type": "opacity",
-      "description": "Used to represent disabled state",
+      "description": "Opacity used in disabled state",
       "rawValue": "{opacity.40}"
     }
   },
@@ -284,7 +284,7 @@
       "default": {
         "value": "1px",
         "type": "borderWidth",
-        "description": "The thickness of a focused element's outline",
+        "description": "Thickness of a focused element's outline",
         "rawValue": "{borderWidth.xs}"
       }
     }
@@ -294,7 +294,7 @@
       "default": {
         "value": "2px",
         "type": "spacing",
-        "description": "The amount of space between a focused element's outline and edge.",
+        "description": "Space between a focused element's outline and edge",
         "rawValue": "{spacing.050}"
       }
     }

--- a/tokens/extra.typography.json
+++ b/tokens/extra.typography.json
@@ -15,6 +15,7 @@
     "40": {
       "value": "40%",
       "type": "opacity",
+      "description": "Opacity used in disabled states",
       "rawValue": "40%"
     },
     "45": {
@@ -1218,7 +1219,7 @@
         "textCase": "none"
       },
       "type": "typography",
-      "description": "Monospace 1\nUsed for Global Status Bar clock",
+      "description": "Monospace 1. Used for Global Status Bar clock",
       "rawValue": {
         "fontFamily": "{fontFamily.sans}",
         "fontWeight": "{fontWeights.medium}",

--- a/tokens/extra.typography.json
+++ b/tokens/extra.typography.json
@@ -3,12 +3,12 @@
     "25": {
       "value": "25%",
       "type": "opacity",
-      "description": "used in drop shadow for scrollbars in light theme ",
+      "description": "Opacity used in drop shadow for scrollbars in light theme",
       "rawValue": "25%"
     },
     "35": {
       "value": "35%",
-      "description": "Used in drop shadow for dialogs in light theme",
+      "description": "Opacity used in drop shadow for dialogs in light theme",
       "type": "opacity",
       "rawValue": "35%"
     },
@@ -19,7 +19,7 @@
     },
     "45": {
       "value": "45%",
-      "description": "Used in drop shadow for dialogs",
+      "description": "Opacity used in drop shadow for dialogs",
       "type": "opacity",
       "rawValue": "45%"
     },
@@ -600,7 +600,7 @@
     "lg": {
       "value": "4px",
       "type": "borderWidth",
-      "description": "large border width",
+      "description": "Large border width",
       "rawValue": "4px"
     }
   },
@@ -608,13 +608,13 @@
     "base": {
       "value": "3px",
       "type": "borderRadius",
-      "description": "The default base border radius",
+      "description": "Default base border radius",
       "rawValue": "3px"
     },
     "circle": {
       "value": "50%",
       "type": "borderRadius",
-      "description": "A completely rounded border radius, used to create circles.",
+      "description": "Completely rounded border radius, used to create circles",
       "rawValue": "50%"
     }
   },
@@ -1168,7 +1168,7 @@
         "textCase": "none"
       },
       "type": "typography",
-      "description": "Display 1. Custom element. Used for Splash Screens.",
+      "description": "Display 1. Custom element. Used for Splash Screens",
       "rawValue": {
         "fontFamily": "{fontFamily.sans}",
         "fontWeight": "{fontWeights.light}",
@@ -1192,7 +1192,7 @@
         "textCase": "none"
       },
       "type": "typography",
-      "description": "Display 2. Custom element. Used for Splash Screens.",
+      "description": "Display 2. Custom element. Used for Splash Screens",
       "rawValue": {
         "fontFamily": "{fontFamily.sans}",
         "fontWeight": "{fontWeights.regular}",
@@ -1218,7 +1218,7 @@
         "textCase": "none"
       },
       "type": "typography",
-      "description": "Monospace 1\nUsed for Global Status Bar clock.",
+      "description": "Monospace 1\nUsed for Global Status Bar clock",
       "rawValue": {
         "fontFamily": "{fontFamily.sans}",
         "fontWeight": "{fontWeights.medium}",

--- a/tokens/ios/base.json
+++ b/tokens/ios/base.json
@@ -104,13 +104,13 @@
         "default": {
           "value": "#4dacff",
           "type": "color",
-          "description": "The color used for links in default state.",
+          "description": "Color used for links in default state",
           "rawValue": "{color.text.interactive.default}"
         },
         "hover": {
           "value": "#4dacff",
           "type": "color",
-          "description": "The color used for links in hover state. Links do not change color on hover.",
+          "description": "Color used for links in hover state. Links do not change color on hover",
           "rawValue": "{link.color.text.default}"
         }
       }
@@ -121,7 +121,7 @@
       "border": {
         "value": "#51555b",
         "type": "color",
-        "description": "The border color used for the Card component.",
+        "description": "Border color used for the Card component",
         "rawValue": "{color.palette.grey.700}"
       }
     }
@@ -131,7 +131,7 @@
       "border": {
         "value": "#000000",
         "type": "color",
-        "description": "The border color used for the Container component.",
+        "description": "Border color used for the Container component",
         "rawValue": "{color.palette.neutral.1000}"
       }
     }
@@ -142,37 +142,37 @@
         "topsecretsci": {
           "value": "#fce83a",
           "type": "color",
-          "description": "The background color of the Top Secret//SCI classification banner.",
+          "description": "Background color of the Top Secret//SCI classification banner",
           "rawValue": "{color.classification.topsecretsci}"
         },
         "topsecret": {
           "value": "#ff8c00",
           "type": "color",
-          "description": "The background color of the Top Secret classification banner.",
+          "description": "Background color of the Top Secret classification banner",
           "rawValue": "{color.classification.topsecret}"
         },
         "secret": {
           "value": "#c8102e",
           "type": "color",
-          "description": "The background color of the Secret classification banner.",
+          "description": "Background color of the Secret classification banner",
           "rawValue": "{color.classification.secret}"
         },
         "confidential": {
           "value": "#0033a0",
           "type": "color",
-          "description": "The background color of the Confidential classification banner.",
+          "description": "Background color of the Confidential classification banner",
           "rawValue": "{color.classification.confidential}"
         },
         "cui": {
           "value": "#502b85",
           "type": "color",
-          "description": "The background color of the CUI classification banner.",
+          "description": "Background color of the CUI classification banner",
           "rawValue": "{color.classification.cui}"
         },
         "unclassified": {
           "value": "#007a33",
           "type": "color",
-          "description": "The background color of the Unclassified classification banner.",
+          "description": "Background color of the Unclassified classification banner",
           "rawValue": "{color.classification.unclassified}"
         }
       }
@@ -185,13 +185,13 @@
           "on-dark": {
             "value": "#ff3838",
             "type": "color",
-            "description": "The fill color of the Critical status symbol on a dark background.",
+            "description": "Fill color of the Critical status symbol on a dark background",
             "rawValue": "{color.palette.red.500}"
           },
           "on-light": {
             "value": "#ff2a04",
             "type": "color",
-            "description": "The fill color of the Critical status symbol on a light background.",
+            "description": "Fill color of the Critical status symbol on a light background",
             "rawValue": "{color.palette.red.600}"
           }
         },
@@ -199,13 +199,13 @@
           "on-dark": {
             "value": "#ffb302",
             "type": "color",
-            "description": "The fill color of the Serious status symbol on a dark background.",
+            "description": "Fill color of the Serious status symbol on a dark background",
             "rawValue": "{color.palette.orange.500}"
           },
           "on-light": {
             "value": "#ffaf3d",
             "type": "color",
-            "description": "The fill color of the Serious status symbol on a light background.",
+            "description": "Fill color of the Serious status symbol on a light background",
             "rawValue": "{color.palette.orange.600}"
           }
         },
@@ -213,13 +213,13 @@
           "on-dark": {
             "value": "#fce83a",
             "type": "color",
-            "description": "The fill color of the Caution status symbol on a dark background.",
+            "description": "Fill color of the Caution status symbol on a dark background",
             "rawValue": "{color.palette.yellow.500}"
           },
           "on-light": {
             "value": "#fad800",
             "type": "color",
-            "description": "The fill color of the Caution status symbol on a light background.",
+            "description": "Fill color of the Caution status symbol on a light background",
             "rawValue": "{color.palette.yellow.600}"
           }
         },
@@ -227,13 +227,13 @@
           "on-dark": {
             "value": "#56f000",
             "type": "color",
-            "description": "The fill color of the Normal status symbol on a dark background.",
+            "description": "Fill color of the Normal status symbol on a dark background",
             "rawValue": "{color.palette.green.500}"
           },
           "on-light": {
             "value": "#00e200",
             "type": "color",
-            "description": "The fill color of the Normal status symbol on a light background.",
+            "description": "Fill color of the Normal status symbol on a light background",
             "rawValue": "{color.palette.green.600}"
           }
         },
@@ -241,13 +241,13 @@
           "on-dark": {
             "value": "#2dccff",
             "type": "color",
-            "description": "The fill color of the Standby status symbol on a dark background.",
+            "description": "Fill color of the Standby status symbol on a dark background",
             "rawValue": "{color.palette.cyan.600}"
           },
           "on-light": {
             "value": "#64d9ff",
             "type": "color",
-            "description": "The fill color of the Standby status symbol on a light background.",
+            "description": "Fill color of the Standby status symbol on a light background",
             "rawValue": "{color.palette.cyan.500}"
           }
         },
@@ -255,13 +255,13 @@
           "on-dark": {
             "value": "#a4abb6",
             "type": "color",
-            "description": "The fill color of the Off status symbol on a dark background.",
+            "description": "Fill color of the Off status symbol on a dark background",
             "rawValue": "{color.palette.grey.500}"
           },
           "on-light": {
             "value": "#7b8089",
             "type": "color",
-            "description": "The fill color of the Off status symbol on a light background.",
+            "description": "Fill color of the Off status symbol on a light background",
             "rawValue": "{color.palette.grey.600}"
           }
         }
@@ -270,37 +270,37 @@
         "critical": {
           "value": "#661102",
           "type": "color",
-          "description": "The border color of the Critical status symbol on light backgrounds.",
+          "description": "Border color of the Critical status symbol on light backgrounds",
           "rawValue": "{color.palette.red.900}"
         },
         "serious": {
           "value": "#664618",
           "type": "color",
-          "description": "The border color of the Serious status symbol on light backgrounds.",
+          "description": "Border color of the Serious status symbol on light backgrounds",
           "rawValue": "{color.palette.orange.900}"
         },
         "caution": {
           "value": "#645600",
           "type": "color",
-          "description": "The border color of the Caution status symbol on light backgrounds.",
+          "description": "Border color of the Caution status symbol on light backgrounds",
           "rawValue": "{color.palette.yellow.900}"
         },
         "normal": {
           "value": "#005a00",
           "type": "color",
-          "description": "The border color of the Normal status symbol on light backgrounds.",
+          "description": "Border color of the Normal status symbol on light backgrounds",
           "rawValue": "{color.palette.green.900}"
         },
         "standby": {
           "value": "#285766",
           "type": "color",
-          "description": "The border color of the Standby status symbol on light backgrounds.",
+          "description": "Border color of the Standby status symbol on light backgrounds",
           "rawValue": "{color.palette.cyan.900}"
         },
         "off": {
           "value": "#3c3e42",
           "type": "color",
-          "description": "The border color of the Off status symbol on light backgrounds.",
+          "description": "Border color of the Off status symbol on light backgrounds",
           "rawValue": "{color.palette.grey.800}"
         }
       }
@@ -309,13 +309,13 @@
       "on-dark": {
         "value": 0,
         "type": "borderWidth",
-        "description": "The border width for status symbols on a dark background",
+        "description": "Border width for status symbols on a dark background",
         "rawValue": "{borderWidth.none}"
       },
       "on-light": {
         "value": "1px",
         "type": "borderWidth",
-        "description": "The border width for status symbols on a light background",
+        "description": "Border width for status symbols on a light background",
         "rawValue": "{borderWidth.xs}"
       }
     }
@@ -327,13 +327,13 @@
           "default": {
             "value": "#4dacff",
             "type": "color",
-            "description": "The primary color used for interactive elements in the Global Status Bar.",
+            "description": "Primary color used for interactive elements in the Global Status Bar",
             "rawValue": "{color.palette.brightblue.500}"
           },
           "hover": {
             "value": "#92cbff",
             "type": "color",
-            "description": "The hover color used for interactive elements in the Global Status Bar.",
+            "description": "Hover color used for interactive elements in the Global Status Bar",
             "rawValue": "{color.palette.brightblue.400}"
           }
         }
@@ -343,13 +343,13 @@
       "background": {
         "value": "#172635",
         "type": "color",
-        "description": "The background color of the Global Status Bar component. ",
+        "description": "Background color of the Global Status Bar component",
         "rawValue": "{color.palette.darkblue.900}"
       },
       "text": {
         "value": "#ffffff",
         "type": "color",
-        "description": "The primary text color used within the Global Status Bar.",
+        "description": "Primary text color used within the Global Status Bar",
         "rawValue": "{color.palette.neutral.000}"
       }
     }
@@ -359,7 +359,7 @@
       "background-track": {
         "value": "1px",
         "type": "borderRadius",
-        "description": "The background track border radius",
+        "description": "Background track border radius",
         "rawValue": "1px"
       }
     }
@@ -368,7 +368,7 @@
     "radius": {
       "value": "2px",
       "type": "borderRadius",
-      "description": "The checkbox border radius",
+      "description": "Checkbox border radius",
       "rawValue": "2px"
     }
   },
@@ -377,13 +377,13 @@
       "inner": {
         "value": "4px",
         "type": "borderRadius",
-        "description": "The inside radio border radius",
+        "description": "Inside radio border radius",
         "rawValue": "4px"
       },
       "outer": {
         "value": "9px",
         "type": "borderRadius",
-        "description": "The outside radio border radius",
+        "description": "Outside radio border radius",
         "rawValue": "9px"
       }
     }
@@ -393,7 +393,7 @@
       "track": {
         "value": "10px",
         "type": "borderRadius",
-        "description": "The switch track's border radius",
+        "description": "Switch track's border radius",
         "rawValue": "10px"
       }
     }
@@ -446,7 +446,7 @@
     "radius": {
       "value": "4px",
       "type": "borderRadius",
-      "description": "The scrollbar's border radius",
+      "description": "Scrollbar's border radius",
       "rawValue": "4px"
     }
   },
@@ -455,13 +455,13 @@
       "inner": {
         "value": "8px",
         "type": "borderRadius",
-        "description": "The inside border radius",
+        "description": "Inside border radius",
         "rawValue": "8px"
       },
       "outer": {
         "value": "10px",
         "type": "borderRadius",
-        "description": "The outside border radius",
+        "description": "Outside border radius",
         "rawValue": "10px"
       }
     }
@@ -537,13 +537,13 @@
       "inner": {
         "value": "23px",
         "type": "borderRadius",
-        "description": "The inside border radius",
+        "description": "Inside border radius",
         "rawValue": "23px"
       },
       "outer": {
         "value": "30px",
         "type": "borderRadius",
-        "description": "The outside border radius",
+        "description": "Outside border radius",
         "rawValue": "30px"
       }
     }
@@ -553,13 +553,13 @@
       "inner": {
         "value": "2px",
         "type": "borderRadius",
-        "description": "The inner radius of Notification Banner outlines.",
+        "description": "Inner radius of Notification Banner outlines",
         "rawValue": "2px"
       },
       "outer": {
         "value": "3px",
         "type": "borderRadius",
-        "description": "The outer radius of Notification Banner outlines.",
+        "description": "Outer radius of Notification Banner outlines",
         "rawValue": "{radius.base}"
       }
     },
@@ -569,43 +569,43 @@
           "normal": {
             "value": "#56f000",
             "type": "color",
-            "description": "The fill color of the Normal Notification Banner background.",
+            "description": "Fill color of the Normal Notification Banner background",
             "rawValue": "{color.status.normal}"
           },
           "caution": {
             "value": "#fce83a",
             "type": "color",
-            "description": "The fill color of the Caution Notification Banner background.",
+            "description": "Fill color of the Caution Notification Banner background",
             "rawValue": "{color.status.caution}"
           },
           "serious": {
             "value": "#ffb302",
             "type": "color",
-            "description": "The fill color of the Serious Notification Banner background.",
+            "description": "Fill color of the Serious Notification Banner background",
             "rawValue": "{color.status.serious}"
           },
           "critical": {
             "value": "#ff3838",
             "type": "color",
-            "description": "The fill color of the Critical Notification Banner background.",
+            "description": "Fill color of the Critical Notification Banner background",
             "rawValue": "{color.status.critical}"
           },
           "standby": {
             "value": "#2dccff",
             "type": "color",
-            "description": "The fill color of the Standby Notification Banner background.",
+            "description": "Fill color of the Standby Notification Banner background",
             "rawValue": "{color.status.standby}"
           },
           "off": {
             "value": "#a4abb6",
             "type": "color",
-            "description": "The fill color of the Off Notification Banner background.",
+            "description": "Fill color of the Off Notification Banner background",
             "rawValue": "{color.status.off}"
           },
           "default": {
             "value": "#4dacff",
             "type": "color",
-            "description": "The fill color of the Default Notification Banner background.",
+            "description": "Fill color of the Default Notification Banner background",
             "rawValue": "{color.border.interactive.default}"
           }
         },
@@ -613,43 +613,43 @@
           "normal": {
             "value": "#56f000",
             "type": "color",
-            "description": "The stroke color of the Normal Notification Banner.",
+            "description": "Stroke color of the Normal Notification Banner",
             "rawValue": "{color.status.normal}"
           },
           "caution": {
             "value": "#fce83a",
             "type": "color",
-            "description": "The stroke color of the Caution Notification Banner.",
+            "description": "Stroke color of the Caution Notification Banner",
             "rawValue": "{color.status.caution}"
           },
           "serious": {
             "value": "#ffb302",
             "type": "color",
-            "description": "The stroke color of the Serious Notification Banner.",
+            "description": "Stroke color of the Serious Notification Banner",
             "rawValue": "{color.status.serious}"
           },
           "critical": {
             "value": "#ff3838",
             "type": "color",
-            "description": "The stroke color of the Critical Notification Banner.",
+            "description": "Stroke color of the Critical Notification Banner",
             "rawValue": "{color.status.critical}"
           },
           "standby": {
             "value": "#2dccff",
             "type": "color",
-            "description": "The stroke color of the Standby Notification Banner.",
+            "description": "Stroke color of the Standby Notification Banner",
             "rawValue": "{color.status.standby}"
           },
           "off": {
             "value": "#a4abb6",
             "type": "color",
-            "description": "The stroke color of the Off Notification Banner.",
+            "description": "Stroke color of the Off Notification Banner",
             "rawValue": "{color.status.off}"
           },
           "default": {
             "value": "#4dacff",
             "type": "color",
-            "description": "The stroke color of the Default Notification Banner.",
+            "description": "Stroke color of the Default Notification Banner",
             "rawValue": "{color.border.interactive.default}"
           }
         }
@@ -662,7 +662,7 @@
         "fill": {
           "value": "#51555b",
           "type": "color",
-          "description": "The fill color for menu dividers",
+          "description": "Fill color for menu dividers",
           "rawValue": "{color.palette.grey.700}"
         }
       }
@@ -704,20 +704,20 @@
       "background": {
         "value": "#3c3e42",
         "type": "color",
-        "description": "The background color for Tooltips",
+        "description": "Background color for Tooltips",
         "rawValue": "{color.palette.grey.800}"
       },
       "text": {
         "value": "#ffffff",
         "type": "color",
-        "description": "The text color for Tooltips",
+        "description": "Text color for Tooltips",
         "rawValue": "{color.text.white}"
       }
     },
     "radius": {
       "value": "1px",
       "type": "borderRadius",
-      "description": "The tooltip border radius",
+      "description": "Tooltip border radius",
       "rawValue": "1px"
     }
   },
@@ -747,25 +747,25 @@
         "default": {
           "value": "#101923",
           "type": "color",
-          "description": "The background color of base elements, like the app or popup menus.",
+          "description": "Background color of base elements, like the app or popup menus",
           "rawValue": "{color.palette.brightblue.900}"
         },
         "header": {
           "value": "#172635",
           "type": "color",
-          "description": "The background color for the header of base elements.",
+          "description": "Background color for the header of base elements",
           "rawValue": "{color.palette.darkblue.900}"
         },
         "hover": {
           "value": "#142435",
           "type": "color",
-          "description": "The background color of base elements, like popup menus, when they are hovered over.",
+          "description": "Background color of base elements, like popup menus, when they are hovered over",
           "rawValue": "{color.palette.brightblue.850}"
         },
         "selected": {
           "value": "#1c3f5e",
           "type": "color",
-          "description": "The background color of base elements, like popup menus, when they are selected.",
+          "description": "Background color of base elements, like popup menus, when they are selected",
           "rawValue": "{color.palette.darkblue.700}"
         }
       },
@@ -773,25 +773,25 @@
         "default": {
           "value": "#1b2d3e",
           "type": "color",
-          "description": "The background color of surface elements, like panels or dialogs.",
+          "description": "Background color of surface elements, like panels or dialogs",
           "rawValue": "{color.palette.darkblue.800}"
         },
         "header": {
           "value": "#172635",
           "type": "color",
-          "description": "The background color for the header of surface elements, including dialogs and table headers.",
+          "description": "Background color for the header of surface elements, including dialogs and table headers",
           "rawValue": "{color.palette.darkblue.900}"
         },
         "hover": {
           "value": "#1c3851",
           "type": "color",
-          "description": "The background color of surface elements, like cards or table rows, when they are hovered over.",
+          "description": "Background color of surface elements, like cards or table rows, when they are hovered over",
           "rawValue": "{color.palette.brightblue.800}"
         },
         "selected": {
           "value": "#1c3f5e",
           "type": "color",
-          "description": "The background color of surface elements, like cards or table rows, when they are selected.",
+          "description": "Background color of surface elements, like cards or table rows, when they are selected",
           "rawValue": "{color.palette.darkblue.700}"
         }
       },
@@ -799,19 +799,19 @@
         "default": {
           "value": "#4dacff",
           "type": "color",
-          "description": "The primary color used for the backgrounds of interactive elements.",
+          "description": "Primary color used for the backgrounds of interactive elements",
           "rawValue": "{color.palette.brightblue.500}"
         },
         "hover": {
           "value": "#92cbff",
           "type": "color",
-          "description": "The hover color used for the backgrounds of interactive elements.",
+          "description": "Hover color used for the backgrounds of interactive elements",
           "rawValue": "{color.palette.brightblue.400}"
         },
         "muted": {
           "value": "#2b659b",
           "type": "color",
-          "description": "A muted version of the primary color used for the background of interactive elements that don't need to be as strong as the primary color.",
+          "description": "Muted version of the primary color used for the background of interactive elements that don't need to be as strong as the primary color",
           "rawValue": "{color.palette.brightblue.700}"
         }
       }
@@ -820,57 +820,57 @@
       "primary": {
         "value": "#ffffff",
         "type": "color",
-        "description": "The primary color used for text within the application.",
+        "description": "Primary color used for text within the application",
         "rawValue": "{color.palette.neutral.000}"
       },
       "secondary": {
         "value": "#d4d8dd",
         "type": "color",
-        "description": "The color used for text when less emphasis is needed.",
+        "description": "Color used for text when less emphasis is needed",
         "rawValue": "{color.palette.grey.300}"
       },
       "placeholder": {
         "value": "#a4abb6",
         "type": "color",
-        "description": "The text color used for placeholder text in input and form fields.",
+        "description": "Text color used for placeholder text in input and form fields",
         "rawValue": "{color.palette.grey.500}"
       },
       "inverse": {
         "value": "#080c11",
         "type": "color",
-        "description": "The color used for text on reversed backgrounds.",
+        "description": "Color used for text on reversed backgrounds",
         "rawValue": "{color.palette.darkblue.950}"
       },
       "interactive": {
         "default": {
           "value": "#4dacff",
           "type": "color",
-          "description": "The primary color used for interactive text elements.",
+          "description": "Primary color used for interactive text elements",
           "rawValue": "{color.palette.brightblue.500}"
         },
         "hover": {
           "value": "#92cbff",
           "type": "color",
-          "description": "The hover color used for interactive text elements. ",
+          "description": "Hover color used for interactive text elements",
           "rawValue": "{color.palette.brightblue.400}"
         }
       },
       "white": {
         "value": "#ffffff",
         "type": "color",
-        "description": "Text that is white across all themes. Used for classification and status banners that do not change color in various themes.",
+        "description": "Text that is white across all themes. Used for classification and status banners that do not change color in various themes",
         "rawValue": "{color.palette.neutral.000}"
       },
       "black": {
         "value": "#000000",
         "type": "color",
-        "description": "Text that is black across all themes. Used for classification and status banners that do not change color in various themes.",
+        "description": "Text that is black across all themes. Used for classification and status banners that do not change color in various themes",
         "rawValue": "{color.palette.neutral.1000}"
       },
       "error": {
         "value": "#ff3838",
         "type": "color",
-        "description": "The text color used for form error messages.",
+        "description": "Text color used for form error messages",
         "rawValue": "{color.palette.red.500}"
       }
     },
@@ -879,33 +879,33 @@
         "default": {
           "value": "#4dacff",
           "type": "color",
-          "description": "The primary color used for the border of interactive elements.",
+          "description": "Primary color used for the border of interactive elements",
           "rawValue": "{color.palette.brightblue.500}"
         },
         "hover": {
           "value": "#92cbff",
           "type": "color",
-          "description": "The hover color used for the border of interactive elements.",
+          "description": "Hover color used for the border of interactive elements",
           "rawValue": "{color.palette.brightblue.400}"
         },
         "muted": {
           "value": "#2b659b",
           "type": "color",
-          "description": "A muted version of the primary color used for the border of interactive elements that don't need to be as strong as the primary color.",
+          "description": "Muted version of the primary color used for the border of interactive elements that don't need to be as strong as the primary color",
           "rawValue": "{color.palette.brightblue.700}"
         }
       },
       "error": {
         "value": "#ff3838",
         "type": "color",
-        "description": "The border color used for form error borders.",
+        "description": "Border color used for form error borders",
         "rawValue": "{color.palette.red.500}"
       },
       "focus": {
         "default": {
           "value": "#da9ce7",
           "type": "color",
-          "description": "The color of a focused element's outline",
+          "description": "Color of a focused element's outline",
           "rawValue": "{color.palette.pink.200}"
         }
       }
@@ -914,37 +914,37 @@
       "critical": {
         "value": "#ff3838",
         "type": "color",
-        "description": "The color used to indicate items with a Critical status. Critical, form error, alert, emergency, urgent.",
+        "description": "Color used to indicate items with a Critical status. Critical, form error, alert, emergency, urgent",
         "rawValue": "{color.palette.red.500}"
       },
       "serious": {
         "value": "#ffb302",
         "type": "color",
-        "description": "The color used to indicate items with a Serious status. Serious, warning, error, needs attention.",
+        "description": "Color used to indicate items with a Serious status. Serious, warning, error, needs attention",
         "rawValue": "{color.palette.orange.500}"
       },
       "caution": {
         "value": "#fce83a",
         "type": "color",
-        "description": "The color used to indicate items with a Caution status. Caution, unstable, unsatisfactory.",
+        "description": "Color used to indicate items with a Caution status. Caution, unstable, unsatisfactory",
         "rawValue": "{color.palette.yellow.500}"
       },
       "normal": {
         "value": "#56f000",
         "type": "color",
-        "description": "The color used to indicate items with a Normal status. Normal, on, ok, fine, go, satisfactory, success.",
+        "description": "Color used to indicate items with a Normal status. Normal, on, ok, fine, go, satisfactory, success",
         "rawValue": "{color.palette.green.500}"
       },
       "standby": {
         "value": "#2dccff",
         "type": "color",
-        "description": "The color used to indicate items with a Standby status. Standby, available, enabled.",
+        "description": "Color used to indicate items with a Standby status. Standby, available, enabled",
         "rawValue": "{color.palette.cyan.600}"
       },
       "off": {
         "value": "#a4abb6",
         "type": "color",
-        "description": "The color used to indicate items with an Off status. Off, unavailable, disabled.",
+        "description": "Color used to indicate items with an Off status. Off, unavailable, disabled",
         "rawValue": "{color.palette.grey.500}"
       }
     },
@@ -952,37 +952,37 @@
       "topsecretsci": {
         "value": "#fce83a",
         "type": "color",
-        "description": "The color used to indicate the Top Secret//SCI classification.",
+        "description": "Color used to indicate the Top Secret//SCI classification",
         "rawValue": "{color.palette.yellow.500}"
       },
       "topsecret": {
         "value": "#ff8c00",
         "type": "color",
-        "description": "The color used to indicate the Top Secret classification.",
+        "description": "Color used to indicate the Top Secret classification",
         "rawValue": "{color.palette.orange.700}"
       },
       "secret": {
         "value": "#c8102e",
         "type": "color",
-        "description": "The color used to indicate the Secret classification.",
+        "description": "Color used to indicate the Secret classification",
         "rawValue": "{color.palette.red.700}"
       },
       "confidential": {
         "value": "#0033a0",
         "type": "color",
-        "description": "The color used to indicate the Confidential classification.",
+        "description": "Color used to indicate the Confidential classification",
         "rawValue": "{color.palette.blue.800}"
       },
       "cui": {
         "value": "#502b85",
         "type": "color",
-        "description": "The color used to indicate the CUI classification.",
+        "description": "Color used to indicate the CUI classification",
         "rawValue": "{color.palette.violet.800}"
       },
       "unclassified": {
         "value": "#007a33",
         "type": "color",
-        "description": "The color used to indicate the Unclassified classification.",
+        "description": "Color used to indicate the Unclassified classification",
         "rawValue": "{color.palette.green.800}"
       }
     },
@@ -1538,12 +1538,12 @@
     "25": {
       "value": "25%",
       "type": "opacity",
-      "description": "used in drop shadow for scrollbars in light theme ",
+      "description": "Opacity used in drop shadow for scrollbars in light theme",
       "rawValue": "25%"
     },
     "35": {
       "value": "35%",
-      "description": "Used in drop shadow for dialogs in light theme",
+      "description": "Opacity used in drop shadow for dialogs in light theme",
       "type": "opacity",
       "rawValue": "35%"
     },
@@ -1554,7 +1554,7 @@
     },
     "45": {
       "value": "45%",
-      "description": "Used in drop shadow for dialogs",
+      "description": "Opacity used in drop shadow for dialogs",
       "type": "opacity",
       "rawValue": "45%"
     },
@@ -1566,7 +1566,7 @@
     "disabled": {
       "value": "40%",
       "type": "opacity",
-      "description": "Used to represent disabled state",
+      "description": "Opacity used in disabled state",
       "rawValue": "{opacity.40}"
     }
   },
@@ -1601,7 +1601,7 @@
       "default": {
         "value": "1px",
         "type": "borderWidth",
-        "description": "The thickness of a focused element's outline",
+        "description": "Thickness of a focused element's outline",
         "rawValue": "{borderWidth.xs}"
       }
     },
@@ -1626,7 +1626,7 @@
     "lg": {
       "value": "4px",
       "type": "borderWidth",
-      "description": "large border width",
+      "description": "Large border width",
       "rawValue": "4px"
     }
   },
@@ -1700,7 +1700,7 @@
       "default": {
         "value": "2px",
         "type": "spacing",
-        "description": "The amount of space between a focused element's outline and edge.",
+        "description": "Space between a focused element's outline and edge",
         "rawValue": "{spacing.050}"
       }
     },
@@ -1719,13 +1719,13 @@
     "base": {
       "value": "3px",
       "type": "borderRadius",
-      "description": "The default base border radius",
+      "description": "Default base border radius",
       "rawValue": "3px"
     },
     "circle": {
       "value": "50%",
       "type": "borderRadius",
-      "description": "A completely rounded border radius, used to create circles.",
+      "description": "Completely rounded border radius, used to create circles",
       "rawValue": "50%"
     }
   },
@@ -2279,7 +2279,7 @@
         "textCase": "none"
       },
       "type": "typography",
-      "description": "Display 1. Custom element. Used for Splash Screens.",
+      "description": "Display 1. Custom element. Used for Splash Screens",
       "rawValue": {
         "fontFamily": "{fontFamily.sans}",
         "fontWeight": "{fontWeights.light}",
@@ -2303,7 +2303,7 @@
         "textCase": "none"
       },
       "type": "typography",
-      "description": "Display 2. Custom element. Used for Splash Screens.",
+      "description": "Display 2. Custom element. Used for Splash Screens",
       "rawValue": {
         "fontFamily": "{fontFamily.sans}",
         "fontWeight": "{fontWeights.regular}",
@@ -2329,7 +2329,7 @@
         "textCase": "none"
       },
       "type": "typography",
-      "description": "Monospace 1\nUsed for Global Status Bar clock.",
+      "description": "Monospace 1\nUsed for Global Status Bar clock",
       "rawValue": {
         "fontFamily": "{fontFamily.sans}",
         "fontWeight": "{fontWeights.medium}",

--- a/tokens/ios/base.json
+++ b/tokens/ios/base.json
@@ -1550,6 +1550,7 @@
     "40": {
       "value": "40%",
       "type": "opacity",
+      "description": "Opacity used in disabled states",
       "rawValue": "40%"
     },
     "45": {
@@ -1566,7 +1567,7 @@
     "disabled": {
       "value": "40%",
       "type": "opacity",
-      "description": "Opacity used in disabled state",
+      "description": "Opacity used to indicate the disabled state",
       "rawValue": "{opacity.40}"
     }
   },
@@ -2329,7 +2330,7 @@
         "textCase": "none"
       },
       "type": "typography",
-      "description": "Monospace 1\nUsed for Global Status Bar clock",
+      "description": "Monospace 1. Used for Global Status Bar clock",
       "rawValue": {
         "fontFamily": "{fontFamily.sans}",
         "fontWeight": "{fontWeights.medium}",

--- a/tokens/ios/light.json
+++ b/tokens/ios/light.json
@@ -104,13 +104,13 @@
         "default": {
           "value": "#4dacff",
           "type": "color",
-          "description": "The color used for links in default state.",
+          "description": "Color used for links in default state",
           "rawValue": "{color.text.interactive.default}"
         },
         "hover": {
           "value": "#4dacff",
           "type": "color",
-          "description": "The color used for links in hover state. Links do not change color on hover.",
+          "description": "Color used for links in hover state. Links do not change color on hover",
           "rawValue": "{link.color.text.default}"
         }
       }
@@ -121,7 +121,7 @@
       "border": {
         "value": "#51555b",
         "type": "color",
-        "description": "The border color used for the Card component.",
+        "description": "Border color used for the Card component",
         "rawValue": "{color.palette.grey.700}"
       }
     }
@@ -131,7 +131,7 @@
       "border": {
         "value": "#000000",
         "type": "color",
-        "description": "The border color used for the Container component.",
+        "description": "Border color used for the Container component",
         "rawValue": "{color.palette.neutral.1000}"
       }
     }
@@ -142,37 +142,37 @@
         "topsecretsci": {
           "value": "#fce83a",
           "type": "color",
-          "description": "The background color of the Top Secret//SCI classification banner.",
+          "description": "Background color of the Top Secret//SCI classification banner",
           "rawValue": "{color.classification.topsecretsci}"
         },
         "topsecret": {
           "value": "#ff8c00",
           "type": "color",
-          "description": "The background color of the Top Secret classification banner.",
+          "description": "Background color of the Top Secret classification banner",
           "rawValue": "{color.classification.topsecret}"
         },
         "secret": {
           "value": "#c8102e",
           "type": "color",
-          "description": "The background color of the Secret classification banner.",
+          "description": "Background color of the Secret classification banner",
           "rawValue": "{color.classification.secret}"
         },
         "confidential": {
           "value": "#0033a0",
           "type": "color",
-          "description": "The background color of the Confidential classification banner.",
+          "description": "Background color of the Confidential classification banner",
           "rawValue": "{color.classification.confidential}"
         },
         "cui": {
           "value": "#502b85",
           "type": "color",
-          "description": "The background color of the CUI classification banner.",
+          "description": "Background color of the CUI classification banner",
           "rawValue": "{color.classification.cui}"
         },
         "unclassified": {
           "value": "#007a33",
           "type": "color",
-          "description": "The background color of the Unclassified classification banner.",
+          "description": "Background color of the Unclassified classification banner",
           "rawValue": "{color.classification.unclassified}"
         }
       }
@@ -185,13 +185,13 @@
           "on-dark": {
             "value": "#ff3838",
             "type": "color",
-            "description": "The fill color of the Critical status symbol on a dark background.",
+            "description": "Fill color of the Critical status symbol on a dark background",
             "rawValue": "{color.palette.red.500}"
           },
           "on-light": {
             "value": "#ff2a04",
             "type": "color",
-            "description": "The fill color of the Critical status symbol on a light background.",
+            "description": "Fill color of the Critical status symbol on a light background",
             "rawValue": "{color.palette.red.600}"
           }
         },
@@ -199,13 +199,13 @@
           "on-dark": {
             "value": "#ffb302",
             "type": "color",
-            "description": "The fill color of the Serious status symbol on a dark background.",
+            "description": "Fill color of the Serious status symbol on a dark background",
             "rawValue": "{color.palette.orange.500}"
           },
           "on-light": {
             "value": "#ffaf3d",
             "type": "color",
-            "description": "The fill color of the Serious status symbol on a light background.",
+            "description": "Fill color of the Serious status symbol on a light background",
             "rawValue": "{color.palette.orange.600}"
           }
         },
@@ -213,13 +213,13 @@
           "on-dark": {
             "value": "#fce83a",
             "type": "color",
-            "description": "The fill color of the Caution status symbol on a dark background.",
+            "description": "Fill color of the Caution status symbol on a dark background",
             "rawValue": "{color.palette.yellow.500}"
           },
           "on-light": {
             "value": "#fad800",
             "type": "color",
-            "description": "The fill color of the Caution status symbol on a light background.",
+            "description": "Fill color of the Caution status symbol on a light background",
             "rawValue": "{color.palette.yellow.600}"
           }
         },
@@ -227,13 +227,13 @@
           "on-dark": {
             "value": "#56f000",
             "type": "color",
-            "description": "The fill color of the Normal status symbol on a dark background.",
+            "description": "Fill color of the Normal status symbol on a dark background",
             "rawValue": "{color.palette.green.500}"
           },
           "on-light": {
             "value": "#00e200",
             "type": "color",
-            "description": "The fill color of the Normal status symbol on a light background.",
+            "description": "Fill color of the Normal status symbol on a light background",
             "rawValue": "{color.palette.green.600}"
           }
         },
@@ -241,13 +241,13 @@
           "on-dark": {
             "value": "#2dccff",
             "type": "color",
-            "description": "The fill color of the Standby status symbol on a dark background.",
+            "description": "Fill color of the Standby status symbol on a dark background",
             "rawValue": "{color.palette.cyan.600}"
           },
           "on-light": {
             "value": "#64d9ff",
             "type": "color",
-            "description": "The fill color of the Standby status symbol on a light background.",
+            "description": "Fill color of the Standby status symbol on a light background",
             "rawValue": "{color.palette.cyan.500}"
           }
         },
@@ -255,13 +255,13 @@
           "on-dark": {
             "value": "#a4abb6",
             "type": "color",
-            "description": "The fill color of the Off status symbol on a dark background.",
+            "description": "Fill color of the Off status symbol on a dark background",
             "rawValue": "{color.palette.grey.500}"
           },
           "on-light": {
             "value": "#7b8089",
             "type": "color",
-            "description": "The fill color of the Off status symbol on a light background.",
+            "description": "Fill color of the Off status symbol on a light background",
             "rawValue": "{color.palette.grey.600}"
           }
         }
@@ -270,37 +270,37 @@
         "critical": {
           "value": "#661102",
           "type": "color",
-          "description": "The border color of the Critical status symbol on light backgrounds.",
+          "description": "Border color of the Critical status symbol on light backgrounds",
           "rawValue": "{color.palette.red.900}"
         },
         "serious": {
           "value": "#664618",
           "type": "color",
-          "description": "The border color of the Serious status symbol on light backgrounds.",
+          "description": "Border color of the Serious status symbol on light backgrounds",
           "rawValue": "{color.palette.orange.900}"
         },
         "caution": {
           "value": "#645600",
           "type": "color",
-          "description": "The border color of the Caution status symbol on light backgrounds.",
+          "description": "Border color of the Caution status symbol on light backgrounds",
           "rawValue": "{color.palette.yellow.900}"
         },
         "normal": {
           "value": "#005a00",
           "type": "color",
-          "description": "The border color of the Normal status symbol on light backgrounds.",
+          "description": "Border color of the Normal status symbol on light backgrounds",
           "rawValue": "{color.palette.green.900}"
         },
         "standby": {
           "value": "#285766",
           "type": "color",
-          "description": "The border color of the Standby status symbol on light backgrounds.",
+          "description": "Border color of the Standby status symbol on light backgrounds",
           "rawValue": "{color.palette.cyan.900}"
         },
         "off": {
           "value": "#3c3e42",
           "type": "color",
-          "description": "The border color of the Off status symbol on light backgrounds.",
+          "description": "Border color of the Off status symbol on light backgrounds",
           "rawValue": "{color.palette.grey.800}"
         }
       }
@@ -309,13 +309,13 @@
       "on-dark": {
         "value": 0,
         "type": "borderWidth",
-        "description": "The border width for status symbols on a dark background",
+        "description": "Border width for status symbols on a dark background",
         "rawValue": "{borderWidth.none}"
       },
       "on-light": {
         "value": "1px",
         "type": "borderWidth",
-        "description": "The border width for status symbols on a light background",
+        "description": "Border width for status symbols on a light background",
         "rawValue": "{borderWidth.xs}"
       }
     }
@@ -327,13 +327,13 @@
           "default": {
             "value": "#4dacff",
             "type": "color",
-            "description": "The primary color used for interactive elements in the Global Status Bar.",
+            "description": "Primary color used for interactive elements in the Global Status Bar",
             "rawValue": "{color.palette.brightblue.500}"
           },
           "hover": {
             "value": "#92cbff",
             "type": "color",
-            "description": "The hover color used for interactive elements in the Global Status Bar.",
+            "description": "Hover color used for interactive elements in the Global Status Bar",
             "rawValue": "{color.palette.brightblue.400}"
           }
         }
@@ -343,13 +343,13 @@
       "background": {
         "value": "#172635",
         "type": "color",
-        "description": "The background color of the Global Status Bar component. ",
+        "description": "Background color of the Global Status Bar component",
         "rawValue": "{color.palette.darkblue.900}"
       },
       "text": {
         "value": "#ffffff",
         "type": "color",
-        "description": "The primary text color used within the Global Status Bar.",
+        "description": "Primary text color used within the Global Status Bar",
         "rawValue": "{color.palette.neutral.000}"
       }
     }
@@ -359,7 +359,7 @@
       "background-track": {
         "value": "1px",
         "type": "borderRadius",
-        "description": "The background track border radius",
+        "description": "Background track border radius",
         "rawValue": "1px"
       }
     }
@@ -368,7 +368,7 @@
     "radius": {
       "value": "2px",
       "type": "borderRadius",
-      "description": "The checkbox border radius",
+      "description": "Checkbox border radius",
       "rawValue": "2px"
     }
   },
@@ -377,13 +377,13 @@
       "inner": {
         "value": "4px",
         "type": "borderRadius",
-        "description": "The inside radio border radius",
+        "description": "Inside radio border radius",
         "rawValue": "4px"
       },
       "outer": {
         "value": "9px",
         "type": "borderRadius",
-        "description": "The outside radio border radius",
+        "description": "Outside radio border radius",
         "rawValue": "9px"
       }
     }
@@ -393,7 +393,7 @@
       "track": {
         "value": "10px",
         "type": "borderRadius",
-        "description": "The switch track's border radius",
+        "description": "Switch track's border radius",
         "rawValue": "10px"
       }
     }
@@ -446,7 +446,7 @@
     "radius": {
       "value": "4px",
       "type": "borderRadius",
-      "description": "The scrollbar's border radius",
+      "description": "Scrollbar's border radius",
       "rawValue": "4px"
     }
   },
@@ -455,13 +455,13 @@
       "inner": {
         "value": "8px",
         "type": "borderRadius",
-        "description": "The inside border radius",
+        "description": "Inside border radius",
         "rawValue": "8px"
       },
       "outer": {
         "value": "10px",
         "type": "borderRadius",
-        "description": "The outside border radius",
+        "description": "Outside border radius",
         "rawValue": "10px"
       }
     }
@@ -537,13 +537,13 @@
       "inner": {
         "value": "23px",
         "type": "borderRadius",
-        "description": "The inside border radius",
+        "description": "Inside border radius",
         "rawValue": "23px"
       },
       "outer": {
         "value": "30px",
         "type": "borderRadius",
-        "description": "The outside border radius",
+        "description": "Outside border radius",
         "rawValue": "30px"
       }
     }
@@ -553,13 +553,13 @@
       "inner": {
         "value": "2px",
         "type": "borderRadius",
-        "description": "The inner radius of Notification Banner outlines.",
+        "description": "Inner radius of Notification Banner outlines",
         "rawValue": "2px"
       },
       "outer": {
         "value": "3px",
         "type": "borderRadius",
-        "description": "The outer radius of Notification Banner outlines.",
+        "description": "Outer radius of Notification Banner outlines",
         "rawValue": "{radius.base}"
       }
     },
@@ -569,43 +569,43 @@
           "normal": {
             "value": "#56f000",
             "type": "color",
-            "description": "The fill color of the Normal Notification Banner background.",
+            "description": "Fill color of the Normal Notification Banner background",
             "rawValue": "{color.status.normal}"
           },
           "caution": {
             "value": "#fce83a",
             "type": "color",
-            "description": "The fill color of the Caution Notification Banner background.",
+            "description": "Fill color of the Caution Notification Banner background",
             "rawValue": "{color.status.caution}"
           },
           "serious": {
             "value": "#ffb302",
             "type": "color",
-            "description": "The fill color of the Serious Notification Banner background.",
+            "description": "Fill color of the Serious Notification Banner background",
             "rawValue": "{color.status.serious}"
           },
           "critical": {
             "value": "#ff3838",
             "type": "color",
-            "description": "The fill color of the Critical Notification Banner background.",
+            "description": "Fill color of the Critical Notification Banner background",
             "rawValue": "{color.status.critical}"
           },
           "standby": {
             "value": "#2dccff",
             "type": "color",
-            "description": "The fill color of the Standby Notification Banner background.",
+            "description": "Fill color of the Standby Notification Banner background",
             "rawValue": "{color.status.standby}"
           },
           "off": {
             "value": "#a4abb6",
             "type": "color",
-            "description": "The fill color of the Off Notification Banner background.",
+            "description": "Fill color of the Off Notification Banner background",
             "rawValue": "{color.status.off}"
           },
           "default": {
             "value": "#4dacff",
             "type": "color",
-            "description": "The fill color of the Default Notification Banner background.",
+            "description": "Fill color of the Default Notification Banner background",
             "rawValue": "{color.border.interactive.default}"
           }
         },
@@ -613,43 +613,43 @@
           "normal": {
             "value": "#56f000",
             "type": "color",
-            "description": "The stroke color of the Normal Notification Banner.",
+            "description": "Stroke color of the Normal Notification Banner",
             "rawValue": "{color.status.normal}"
           },
           "caution": {
             "value": "#fce83a",
             "type": "color",
-            "description": "The stroke color of the Caution Notification Banner.",
+            "description": "Stroke color of the Caution Notification Banner",
             "rawValue": "{color.status.caution}"
           },
           "serious": {
             "value": "#ffb302",
             "type": "color",
-            "description": "The stroke color of the Serious Notification Banner.",
+            "description": "Stroke color of the Serious Notification Banner",
             "rawValue": "{color.status.serious}"
           },
           "critical": {
             "value": "#ff3838",
             "type": "color",
-            "description": "The stroke color of the Critical Notification Banner.",
+            "description": "Stroke color of the Critical Notification Banner",
             "rawValue": "{color.status.critical}"
           },
           "standby": {
             "value": "#2dccff",
             "type": "color",
-            "description": "The stroke color of the Standby Notification Banner.",
+            "description": "Stroke color of the Standby Notification Banner",
             "rawValue": "{color.status.standby}"
           },
           "off": {
             "value": "#a4abb6",
             "type": "color",
-            "description": "The stroke color of the Off Notification Banner.",
+            "description": "Stroke color of the Off Notification Banner",
             "rawValue": "{color.status.off}"
           },
           "default": {
             "value": "#4dacff",
             "type": "color",
-            "description": "The stroke color of the Default Notification Banner.",
+            "description": "Stroke color of the Default Notification Banner",
             "rawValue": "{color.border.interactive.default}"
           }
         }
@@ -662,7 +662,7 @@
         "fill": {
           "value": "#51555b",
           "type": "color",
-          "description": "The fill color for menu dividers",
+          "description": "Fill color for menu dividers",
           "rawValue": "{color.palette.grey.700}"
         }
       }
@@ -704,20 +704,20 @@
       "background": {
         "value": "#3c3e42",
         "type": "color",
-        "description": "The background color for Tooltips",
+        "description": "Background color for Tooltips",
         "rawValue": "{color.palette.grey.800}"
       },
       "text": {
         "value": "#ffffff",
         "type": "color",
-        "description": "The text color for Tooltips",
+        "description": "Text color for Tooltips",
         "rawValue": "{color.text.white}"
       }
     },
     "radius": {
       "value": "1px",
       "type": "borderRadius",
-      "description": "The tooltip border radius",
+      "description": "Tooltip border radius",
       "rawValue": "1px"
     }
   },
@@ -747,25 +747,25 @@
         "default": {
           "value": "#101923",
           "type": "color",
-          "description": "The background color of base elements, like the app or popup menus.",
+          "description": "Background color of base elements, like the app or popup menus",
           "rawValue": "{color.palette.brightblue.900}"
         },
         "header": {
           "value": "#172635",
           "type": "color",
-          "description": "The background color for the header of base elements.",
+          "description": "Background color for the header of base elements",
           "rawValue": "{color.palette.darkblue.900}"
         },
         "hover": {
           "value": "#142435",
           "type": "color",
-          "description": "The background color of base elements, like popup menus, when they are hovered over.",
+          "description": "Background color of base elements, like popup menus, when they are hovered over",
           "rawValue": "{color.palette.brightblue.850}"
         },
         "selected": {
           "value": "#1c3f5e",
           "type": "color",
-          "description": "The background color of base elements, like popup menus, when they are selected.",
+          "description": "Background color of base elements, like popup menus, when they are selected",
           "rawValue": "{color.palette.darkblue.700}"
         }
       },
@@ -773,25 +773,25 @@
         "default": {
           "value": "#1b2d3e",
           "type": "color",
-          "description": "The background color of surface elements, like panels or dialogs.",
+          "description": "Background color of surface elements, like panels or dialogs",
           "rawValue": "{color.palette.darkblue.800}"
         },
         "header": {
           "value": "#172635",
           "type": "color",
-          "description": "The background color for the header of surface elements, including dialogs and table headers.",
+          "description": "Background color for the header of surface elements, including dialogs and table headers",
           "rawValue": "{color.palette.darkblue.900}"
         },
         "hover": {
           "value": "#1c3851",
           "type": "color",
-          "description": "The background color of surface elements, like cards or table rows, when they are hovered over.",
+          "description": "Background color of surface elements, like cards or table rows, when they are hovered over",
           "rawValue": "{color.palette.brightblue.800}"
         },
         "selected": {
           "value": "#1c3f5e",
           "type": "color",
-          "description": "The background color of surface elements, like cards or table rows, when they are selected.",
+          "description": "Background color of surface elements, like cards or table rows, when they are selected",
           "rawValue": "{color.palette.darkblue.700}"
         }
       },
@@ -799,19 +799,19 @@
         "default": {
           "value": "#4dacff",
           "type": "color",
-          "description": "The primary color used for the backgrounds of interactive elements.",
+          "description": "Primary color used for the backgrounds of interactive elements",
           "rawValue": "{color.palette.brightblue.500}"
         },
         "hover": {
           "value": "#92cbff",
           "type": "color",
-          "description": "The hover color used for the backgrounds of interactive elements.",
+          "description": "Hover color used for the backgrounds of interactive elements",
           "rawValue": "{color.palette.brightblue.400}"
         },
         "muted": {
           "value": "#2b659b",
           "type": "color",
-          "description": "A muted version of the primary color used for the background of interactive elements that don't need to be as strong as the primary color.",
+          "description": "Muted version of the primary color used for the background of interactive elements that don't need to be as strong as the primary color",
           "rawValue": "{color.palette.brightblue.700}"
         }
       }
@@ -820,57 +820,57 @@
       "primary": {
         "value": "#ffffff",
         "type": "color",
-        "description": "The primary color used for text within the application.",
+        "description": "Primary color used for text within the application",
         "rawValue": "{color.palette.neutral.000}"
       },
       "secondary": {
         "value": "#d4d8dd",
         "type": "color",
-        "description": "The color used for text when less emphasis is needed.",
+        "description": "Color used for text when less emphasis is needed",
         "rawValue": "{color.palette.grey.300}"
       },
       "placeholder": {
         "value": "#a4abb6",
         "type": "color",
-        "description": "The text color used for placeholder text in input and form fields.",
+        "description": "Text color used for placeholder text in input and form fields",
         "rawValue": "{color.palette.grey.500}"
       },
       "inverse": {
         "value": "#080c11",
         "type": "color",
-        "description": "The color used for text on reversed backgrounds.",
+        "description": "Color used for text on reversed backgrounds",
         "rawValue": "{color.palette.darkblue.950}"
       },
       "interactive": {
         "default": {
           "value": "#4dacff",
           "type": "color",
-          "description": "The primary color used for interactive text elements.",
+          "description": "Primary color used for interactive text elements",
           "rawValue": "{color.palette.brightblue.500}"
         },
         "hover": {
           "value": "#92cbff",
           "type": "color",
-          "description": "The hover color used for interactive text elements. ",
+          "description": "Hover color used for interactive text elements",
           "rawValue": "{color.palette.brightblue.400}"
         }
       },
       "white": {
         "value": "#ffffff",
         "type": "color",
-        "description": "Text that is white across all themes. Used for classification and status banners that do not change color in various themes.",
+        "description": "Text that is white across all themes. Used for classification and status banners that do not change color in various themes",
         "rawValue": "{color.palette.neutral.000}"
       },
       "black": {
         "value": "#000000",
         "type": "color",
-        "description": "Text that is black across all themes. Used for classification and status banners that do not change color in various themes.",
+        "description": "Text that is black across all themes. Used for classification and status banners that do not change color in various themes",
         "rawValue": "{color.palette.neutral.1000}"
       },
       "error": {
         "value": "#ff3838",
         "type": "color",
-        "description": "The text color used for form error messages.",
+        "description": "Text color used for form error messages",
         "rawValue": "{color.palette.red.500}"
       }
     },
@@ -879,33 +879,33 @@
         "default": {
           "value": "#4dacff",
           "type": "color",
-          "description": "The primary color used for the border of interactive elements.",
+          "description": "Primary color used for the border of interactive elements",
           "rawValue": "{color.palette.brightblue.500}"
         },
         "hover": {
           "value": "#92cbff",
           "type": "color",
-          "description": "The hover color used for the border of interactive elements.",
+          "description": "Hover color used for the border of interactive elements",
           "rawValue": "{color.palette.brightblue.400}"
         },
         "muted": {
           "value": "#2b659b",
           "type": "color",
-          "description": "A muted version of the primary color used for the border of interactive elements that don't need to be as strong as the primary color.",
+          "description": "Muted version of the primary color used for the border of interactive elements that don't need to be as strong as the primary color",
           "rawValue": "{color.palette.brightblue.700}"
         }
       },
       "error": {
         "value": "#ff3838",
         "type": "color",
-        "description": "The border color used for form error borders.",
+        "description": "Border color used for form error borders",
         "rawValue": "{color.palette.red.500}"
       },
       "focus": {
         "default": {
           "value": "#da9ce7",
           "type": "color",
-          "description": "The color of a focused element's outline",
+          "description": "Color of a focused element's outline",
           "rawValue": "{color.palette.pink.200}"
         }
       }
@@ -914,37 +914,37 @@
       "critical": {
         "value": "#ff3838",
         "type": "color",
-        "description": "The color used to indicate items with a Critical status. Critical, form error, alert, emergency, urgent.",
+        "description": "Color used to indicate items with a Critical status. Critical, form error, alert, emergency, urgent",
         "rawValue": "{color.palette.red.500}"
       },
       "serious": {
         "value": "#ffb302",
         "type": "color",
-        "description": "The color used to indicate items with a Serious status. Serious, warning, error, needs attention.",
+        "description": "Color used to indicate items with a Serious status. Serious, warning, error, needs attention",
         "rawValue": "{color.palette.orange.500}"
       },
       "caution": {
         "value": "#fce83a",
         "type": "color",
-        "description": "The color used to indicate items with a Caution status. Caution, unstable, unsatisfactory.",
+        "description": "Color used to indicate items with a Caution status. Caution, unstable, unsatisfactory",
         "rawValue": "{color.palette.yellow.500}"
       },
       "normal": {
         "value": "#56f000",
         "type": "color",
-        "description": "The color used to indicate items with a Normal status. Normal, on, ok, fine, go, satisfactory, success.",
+        "description": "Color used to indicate items with a Normal status. Normal, on, ok, fine, go, satisfactory, success",
         "rawValue": "{color.palette.green.500}"
       },
       "standby": {
         "value": "#2dccff",
         "type": "color",
-        "description": "The color used to indicate items with a Standby status. Standby, available, enabled.",
+        "description": "Color used to indicate items with a Standby status. Standby, available, enabled",
         "rawValue": "{color.palette.cyan.600}"
       },
       "off": {
         "value": "#a4abb6",
         "type": "color",
-        "description": "The color used to indicate items with an Off status. Off, unavailable, disabled.",
+        "description": "Color used to indicate items with an Off status. Off, unavailable, disabled",
         "rawValue": "{color.palette.grey.500}"
       }
     },
@@ -952,37 +952,37 @@
       "topsecretsci": {
         "value": "#fce83a",
         "type": "color",
-        "description": "The color used to indicate the Top Secret//SCI classification.",
+        "description": "Color used to indicate the Top Secret//SCI classification",
         "rawValue": "{color.palette.yellow.500}"
       },
       "topsecret": {
         "value": "#ff8c00",
         "type": "color",
-        "description": "The color used to indicate the Top Secret classification.",
+        "description": "Color used to indicate the Top Secret classification",
         "rawValue": "{color.palette.orange.700}"
       },
       "secret": {
         "value": "#c8102e",
         "type": "color",
-        "description": "The color used to indicate the Secret classification.",
+        "description": "Color used to indicate the Secret classification",
         "rawValue": "{color.palette.red.700}"
       },
       "confidential": {
         "value": "#0033a0",
         "type": "color",
-        "description": "The color used to indicate the Confidential classification.",
+        "description": "Color used to indicate the Confidential classification",
         "rawValue": "{color.palette.blue.800}"
       },
       "cui": {
         "value": "#502b85",
         "type": "color",
-        "description": "The color used to indicate the CUI classification.",
+        "description": "Color used to indicate the CUI classification",
         "rawValue": "{color.palette.violet.800}"
       },
       "unclassified": {
         "value": "#007a33",
         "type": "color",
-        "description": "The color used to indicate the Unclassified classification.",
+        "description": "Color used to indicate the Unclassified classification",
         "rawValue": "{color.palette.green.800}"
       }
     },
@@ -1538,12 +1538,12 @@
     "25": {
       "value": "25%",
       "type": "opacity",
-      "description": "used in drop shadow for scrollbars in light theme ",
+      "description": "Opacity used in drop shadow for scrollbars in light theme",
       "rawValue": "25%"
     },
     "35": {
       "value": "35%",
-      "description": "Used in drop shadow for dialogs in light theme",
+      "description": "Opacity used in drop shadow for dialogs in light theme",
       "type": "opacity",
       "rawValue": "35%"
     },
@@ -1554,7 +1554,7 @@
     },
     "45": {
       "value": "45%",
-      "description": "Used in drop shadow for dialogs",
+      "description": "Opacity used in drop shadow for dialogs",
       "type": "opacity",
       "rawValue": "45%"
     },
@@ -1566,7 +1566,7 @@
     "disabled": {
       "value": "40%",
       "type": "opacity",
-      "description": "Used to represent disabled state",
+      "description": "Opacity used in disabled state",
       "rawValue": "{opacity.40}"
     }
   },
@@ -1601,7 +1601,7 @@
       "default": {
         "value": "1px",
         "type": "borderWidth",
-        "description": "The thickness of a focused element's outline",
+        "description": "Thickness of a focused element's outline",
         "rawValue": "{borderWidth.xs}"
       }
     },
@@ -1626,7 +1626,7 @@
     "lg": {
       "value": "4px",
       "type": "borderWidth",
-      "description": "large border width",
+      "description": "Large border width",
       "rawValue": "4px"
     }
   },
@@ -1700,7 +1700,7 @@
       "default": {
         "value": "2px",
         "type": "spacing",
-        "description": "The amount of space between a focused element's outline and edge.",
+        "description": "Space between a focused element's outline and edge",
         "rawValue": "{spacing.050}"
       }
     },
@@ -1719,13 +1719,13 @@
     "base": {
       "value": "3px",
       "type": "borderRadius",
-      "description": "The default base border radius",
+      "description": "Default base border radius",
       "rawValue": "3px"
     },
     "circle": {
       "value": "50%",
       "type": "borderRadius",
-      "description": "A completely rounded border radius, used to create circles.",
+      "description": "Completely rounded border radius, used to create circles",
       "rawValue": "50%"
     }
   },
@@ -2279,7 +2279,7 @@
         "textCase": "none"
       },
       "type": "typography",
-      "description": "Display 1. Custom element. Used for Splash Screens.",
+      "description": "Display 1. Custom element. Used for Splash Screens",
       "rawValue": {
         "fontFamily": "{fontFamily.sans}",
         "fontWeight": "{fontWeights.light}",
@@ -2303,7 +2303,7 @@
         "textCase": "none"
       },
       "type": "typography",
-      "description": "Display 2. Custom element. Used for Splash Screens.",
+      "description": "Display 2. Custom element. Used for Splash Screens",
       "rawValue": {
         "fontFamily": "{fontFamily.sans}",
         "fontWeight": "{fontWeights.regular}",
@@ -2329,7 +2329,7 @@
         "textCase": "none"
       },
       "type": "typography",
-      "description": "Monospace 1\nUsed for Global Status Bar clock.",
+      "description": "Monospace 1\nUsed for Global Status Bar clock",
       "rawValue": {
         "fontFamily": "{fontFamily.sans}",
         "fontWeight": "{fontWeights.medium}",

--- a/tokens/ios/light.json
+++ b/tokens/ios/light.json
@@ -1550,6 +1550,7 @@
     "40": {
       "value": "40%",
       "type": "opacity",
+      "description": "Opacity used in disabled states",
       "rawValue": "40%"
     },
     "45": {
@@ -1566,7 +1567,7 @@
     "disabled": {
       "value": "40%",
       "type": "opacity",
-      "description": "Opacity used in disabled state",
+      "description": "Opacity used to indicate the disabled state",
       "rawValue": "{opacity.40}"
     }
   },
@@ -2329,7 +2330,7 @@
         "textCase": "none"
       },
       "type": "typography",
-      "description": "Monospace 1\nUsed for Global Status Bar clock",
+      "description": "Monospace 1. Used for Global Status Bar clock",
       "rawValue": {
         "fontFamily": "{fontFamily.sans}",
         "fontWeight": "{fontWeights.medium}",

--- a/tokens/theme/light.json
+++ b/tokens/theme/light.json
@@ -5,25 +5,25 @@
         "default": {
           "value": "#ffffff",
           "type": "color",
-          "description": "The background color of surface elements, like panels or dialogs.",
+          "description": "Background color of surface elements, like panels or dialogs",
           "rawValue": "{color.palette.neutral.000}"
         },
         "header": {
           "value": "#f5f6f9",
           "type": "color",
-          "description": "The background color for the header of surface elements, including dialogs and table headers.",
+          "description": "Background color for the header of surface elements, including dialogs and table headers",
           "rawValue": "{color.palette.grey.100}"
         },
         "selected": {
           "value": "#cee9fc",
           "type": "color",
-          "description": "The background color of surface elements, like cards or table rows, when they are selected.",
+          "description": "Background color of surface elements, like cards or table rows, when they are selected",
           "rawValue": "{color.palette.brightblue.200}"
         },
         "hover": {
           "value": "#daeeff",
           "type": "color",
-          "description": "The background color of surface elements, like cards or table rows, when they are hovered over.",
+          "description": "Background color of surface elements, like cards or table rows, when they are hovered over",
           "rawValue": "{color.palette.brightblue.100}"
         }
       },
@@ -31,25 +31,25 @@
         "default": {
           "value": "#eaeef4",
           "type": "color",
-          "description": "The background color of base elements, like the app or popup menus.",
+          "description": "Background color of base elements, like the app or popup menus",
           "rawValue": "{color.palette.grey.200}"
         },
         "header": {
           "value": "#f5f6f9",
           "type": "color",
-          "description": "The background color for the header of base elements.",
+          "description": "Background color for the header of base elements",
           "rawValue": "{color.palette.grey.100}"
         },
         "hover": {
           "value": "#98bdd3",
           "type": "color",
-          "description": "The background color of base elements, like popup menus, when they are hovered over.",
+          "description": "Background color of base elements, like popup menus, when they are hovered over",
           "rawValue": "{color.palette.darkblue.200}"
         },
         "selected": {
           "value": "#cee9fc",
           "type": "color",
-          "description": "The background color of base elements, like popup menus, when they are selected.",
+          "description": "Background color of base elements, like popup menus, when they are selected",
           "rawValue": "{color.palette.brightblue.200}"
         }
       },
@@ -57,19 +57,19 @@
         "default": {
           "value": "#005a8f",
           "type": "color",
-          "description": "The primary color used for the backgrounds of interactive elements.",
+          "description": "Primary color used for the backgrounds of interactive elements",
           "rawValue": "{color.palette.darkblue.500}"
         },
         "hover": {
           "value": "#004872",
           "type": "color",
-          "description": "The hover color used for the backgrounds of interactive elements.",
+          "description": "Hover color used for the backgrounds of interactive elements",
           "rawValue": "{color.palette.darkblue.600}"
         },
         "muted": {
           "value": "#2f7aa7",
           "type": "color",
-          "description": "A muted version of the primary color used for the background of interactive elements that don't need to be as strong as the primary color.",
+          "description": "Muted version of the primary color used for the background of interactive elements that don't need to be as strong as the primary color",
           "rawValue": "{color.palette.darkblue.400}"
         }
       }
@@ -78,45 +78,45 @@
       "primary": {
         "value": "#292a2d",
         "type": "color",
-        "description": "The primary color used for text within the application.",
+        "description": "Primary color used for text within the application",
         "rawValue": "{color.palette.grey.900}"
       },
       "secondary": {
         "value": "#51555b",
         "type": "color",
-        "description": "The color used for text when less emphasis is needed.",
+        "description": "Color used for text when less emphasis is needed",
         "rawValue": "{color.palette.grey.700}"
       },
       "placeholder": {
         "value": "#7b8089",
         "type": "color",
-        "description": "The text color used for placeholder text in input and form fields.",
+        "description": "Text color used for placeholder text in input and form fields",
         "rawValue": "{color.palette.grey.600}"
       },
       "inverse": {
         "value": "#ffffff",
         "type": "color",
-        "description": "The color used for text on reversed backgrounds.",
+        "description": "Color used for text on reversed backgrounds",
         "rawValue": "{color.palette.neutral.000}"
       },
       "interactive": {
         "default": {
           "value": "#005a8f",
           "type": "color",
-          "description": "The primary color used for interactive text elements.",
+          "description": "Primary color used for interactive text elements",
           "rawValue": "{color.palette.darkblue.500}"
         },
         "hover": {
           "value": "#004872",
           "type": "color",
-          "description": "The hover color used for interactive text elements. ",
+          "description": "Hover color used for interactive text elements",
           "rawValue": "{color.palette.darkblue.600}"
         }
       },
       "error": {
         "value": "#c8102e",
         "type": "color",
-        "description": "The text color used for form error messages.",
+        "description": "Text color used for form error messages",
         "rawValue": "{color.palette.red.700}"
       }
     },
@@ -125,33 +125,33 @@
         "default": {
           "value": "#005a8f",
           "type": "color",
-          "description": "The primary color used for the border of interactive elements.",
+          "description": "Primary color used for the border of interactive elements",
           "rawValue": "{color.palette.darkblue.500}"
         },
         "hover": {
           "value": "#004872",
           "type": "color",
-          "description": "The hover color used for the border of interactive elements.",
+          "description": "Hover color used for the border of interactive elements",
           "rawValue": "{color.palette.darkblue.600}"
         },
         "muted": {
           "value": "#2f7aa7",
           "type": "color",
-          "description": "A muted version of the primary color used for the border of interactive elements that don't need to be as strong as the primary color.",
+          "description": "Muted version of the primary color used for the border of interactive elements that don't need to be as strong as the primary color",
           "rawValue": "{color.palette.darkblue.400}"
         }
       },
       "error": {
         "value": "#c8102e",
         "type": "color",
-        "description": "The border color used for form error borders.",
+        "description": "Border color used for form error borders",
         "rawValue": "{color.palette.red.700}"
       },
       "focus": {
         "default": {
           "value": "#b534ce",
           "type": "color",
-          "description": "The color of a focused element's outline",
+          "description": "Color of a focused element's outline",
           "rawValue": "{color.palette.pink.400}"
         }
       }
@@ -160,37 +160,37 @@
       "critical": {
         "value": "#ff2a04",
         "type": "color",
-        "description": "The fill color of the Critical status symbol on a light background.",
+        "description": "Fill color of the Critical status symbol on a light background",
         "rawValue": "{color.palette.red.600}"
       },
       "serious": {
         "value": "#ffaf3d",
         "type": "color",
-        "description": "The fill color of the Serious status symbol on a light background.",
+        "description": "Fill color of the Serious status symbol on a light background",
         "rawValue": "{color.palette.orange.600}"
       },
       "caution": {
         "value": "#fad800",
         "type": "color",
-        "description": "The fill color of the Caution status symbol on a light background.",
+        "description": "Fill color of the Caution status symbol on a light background",
         "rawValue": "{color.palette.yellow.600}"
       },
       "normal": {
         "value": "#00e200",
         "type": "color",
-        "description": "The fill color of the Normal status symbol on a light background.",
+        "description": "Fill color of the Normal status symbol on a light background",
         "rawValue": "{color.palette.green.600}"
       },
       "standby": {
         "value": "#64d9ff",
         "type": "color",
-        "description": "The fill color of the Standby status symbol on a light background.",
+        "description": "Fill color of the Standby status symbol on a light background",
         "rawValue": "{color.palette.cyan.500}"
       },
       "off": {
         "value": "#7b8089",
         "type": "color",
-        "description": "The fill color of the Off status symbol on a light background.",
+        "description": "Fill color of the Off status symbol on a light background",
         "rawValue": "{color.palette.grey.600}"
       }
     }
@@ -274,13 +274,13 @@
           "default": {
             "value": "#4dacff",
             "type": "color",
-            "description": "The primary color used for interactive elements in the Global Status Bar.",
+            "description": "Primary color used for interactive elements in the Global Status Bar",
             "rawValue": "{color.palette.brightblue.500}"
           },
           "hover": {
             "value": "#92cbff",
             "type": "color",
-            "description": "The hover color used for interactive elements in the Global Status Bar.",
+            "description": "Hover color used for interactive elements in the Global Status Bar",
             "rawValue": "{color.palette.brightblue.400}"
           }
         }
@@ -290,13 +290,13 @@
       "background": {
         "value": "#172635",
         "type": "color",
-        "description": "The background color of the Global Status Bar component. ",
+        "description": "Background color of the Global Status Bar component",
         "rawValue": "{color.palette.darkblue.900}"
       },
       "text": {
         "value": "#ffffff",
         "type": "color",
-        "description": "The primary text color used within the Global Status Bar.",
+        "description": "Primary text color used within the Global Status Bar",
         "rawValue": "{color.palette.neutral.000}"
       }
     }
@@ -374,7 +374,7 @@
           "normal": {
             "value": "#00e200",
             "type": "color",
-            "description": "The fill color of the Normal Notification Banner background.",
+            "description": "Fill color of the Normal Notification Banner background",
             "rawValue": "{color.status.normal}"
           },
           "caution": {
@@ -453,13 +453,13 @@
       "background": {
         "value": "#bbc1c9",
         "type": "color",
-        "description": "The background color for Tooltips",
+        "description": "Background color for Tooltips",
         "rawValue": "{color.palette.grey.400}"
       },
       "text": {
         "value": "#000000",
         "type": "color",
-        "description": "The text color for Tooltips",
+        "description": "Text color for Tooltips",
         "rawValue": "{color.text.black}"
       }
     }


### PR DESCRIPTION
- Updates descriptions from "The X thing of Y" to "X thing of Y". (RegExp: `"description": "The \w"`)
- Updates descriptions from "used in" to "Opacity used in". (RegExp: `"description": "[Uu]sed in"`)
- Sets all descriptions to begin with a capital letter. (RegExp: `"description": "[a-z]`)
- Removes any period at the end of a description. (RegExp: `"description": "[^"]+\."`)
- Removes any empty spaces ending a description. (RegExp: `"description": "[^"]+ "`)